### PR TITLE
Update README with link to new CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,10 +54,11 @@ Stages are ordered by the pipeline. Steps within the codegen and build stages ar
 The LabVIEW source for this repository is saved for LabVIEW 2014, but is forward compatible to newer versions.
 
 ## Dependencies
-The following top-level dependencies are required to build and use the repository:
+The following top-level dependencies are required on the build machine to use the repository:
 
-[LabVIEW Professional Development System](http:/ni.com/labview)
-[LabVIEW Command Line Interface](https://github.com/JamesMc86/LabVIEW-CLI/releases) (LabVIEW CLI >= 1.4.0.7 in VIPM)
+* [LabVIEW Professional Development System](http:/ni.com/labview)
+* [LabVIEW Command Line Interface](http://www.ni.com/download/labview-command-line-interface-18.0/7545/en/)
+* [Python](https://www.python.org/downloads/) (Version 3.6.3 or later)
 
 ## License
 The NI VeriStand Custom Device Testing Tools are licensed under an MIT-style license (see LICENSE). Other incorporated projects may be licensed under different licenses. All licenses allow for non-commercial and commercial use.


### PR DESCRIPTION
[x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-custom-device-build-tools/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Links to the LabVIEW CLI that is now used by the build tools. Also makes note that Python must be installed on the build machine to use the build tools.

### Why should this Pull Request be merged?

It contains the latest information about what is needed for a build machine setup to use the build tools.

### What testing has been done?

Tested links go to correct locations.
