### PR TITLE
Build nipkg of binaries

### DIFF
--- a/src/ni/vsbuild/Pipeline.groovy
+++ b/src/ni/vsbuild/Pipeline.groovy
@@ -39,11 +39,15 @@ class Pipeline implements Serializable {
          stages << new Package(script, buildConfiguration, lvVersion)
       }
 
+      // The plan is to enable automatic merging from master to
+      // release or hotfix branch packages and not build packages
+      // for any other branches, including master. The version must
+      // be appended to the release or hotfix branch name after a
+      // dash (-) or slash (/).
       def shouldBuildPackage() {
          return buildConfiguration.packageInfo &&
             (script.env.BRANCH_NAME.startsWith("release") ||
-            script.env.BRANCH_NAME.startsWith("hotfix") ||
-            script.env.BRANCH_NAME == "master")
+            script.env.BRANCH_NAME.startsWith("hotfix"))
       }
 
       def buildPipeline() {         

--- a/src/ni/vsbuild/Pipeline.groovy
+++ b/src/ni/vsbuild/Pipeline.groovy
@@ -39,6 +39,13 @@ class Pipeline implements Serializable {
          stages << new Package(script, buildConfiguration, lvVersion)
       }
 
+      def shouldBuildPackage() {
+         return buildConfiguration.packageInfo &&
+            (script.env.BRANCH_NAME.startsWith("release") ||
+            script.env.BRANCH_NAME.startsWith("hotfix") ||
+            script.env.BRANCH_NAME == "master")
+      }
+
       def buildPipeline() {         
          if(buildConfiguration.codegen || buildConfiguration.projects) {
             withCodegenStage()
@@ -48,7 +55,7 @@ class Pipeline implements Serializable {
             withBuildStage()
          }
 
-         if(buildConfiguration.packageInfo) {
+         if(shouldBuildPackage()) {
             withPackageStage()
          }
 

--- a/src/ni/vsbuild/packages/AbstractPackage.groovy
+++ b/src/ni/vsbuild/packages/AbstractPackage.groovy
@@ -3,23 +3,21 @@ package ni.vsbuild.packages
 abstract class AbstractPackage implements Buildable {
 
    def script
-   def name
    def type
    def payloadDir
 
-   AbstractPackage(script, packageInfo, payloadDir) {
+   AbstractPackage(script, packageInfo) {
       this.script = script
-      this.name = packageInfo.get('name')
       this.type = packageInfo.get('type')
-      this.payloadDir = payloadDir
+      this.payloadDir = packageInfo.get('payload_dir')
    }
 
-   void build() {
-      script.echo "Building package $name.$type..."
-      buildPackage()
-      script.echo "Package $name.$type built."
+   void build(lvVersion) {
+      script.echo "Building $type package..."
+      buildPackage(lvVersion)
+      script.echo "$type package built."
    }
 
-   abstract void buildPackage()
+   abstract void buildPackage(lvVersion)
 
 }

--- a/src/ni/vsbuild/packages/Buildable.groovy
+++ b/src/ni/vsbuild/packages/Buildable.groovy
@@ -2,6 +2,6 @@ package ni.vsbuild.packages
 
 interface Buildable extends Serializable {
 
-   void build()
+   void build(lvVersion)
 
 }

--- a/src/ni/vsbuild/packages/Nipkg.groovy
+++ b/src/ni/vsbuild/packages/Nipkg.groovy
@@ -2,36 +2,100 @@ package ni.vsbuild.packages
 
 class Nipkg extends AbstractPackage {
 
-   def pkgVersion
-   def maintainer
-   def description
-   def homepage
-   def displayName
-   def eulaDependency
-   def dependencies
-   
-   Nipkg(script, packageInfo, payloadDir) {
-      super(script, packageInfo, payloadDir)
-      this.pkgVersion = packageInfo.get('version')
-      this.maintainer = packageInfo.get('maintainer')
-      this.description = packageInfo.get('description')
-      this.homepage = packageInfo.get('homepage')
-      this.displayName = packageInfo.get('display_name')
-      this.eulaDependency = packageInfo.get('eula_dependency')
-      this.dependencies = packageInfo.get('dependencies')
+   static final String PACKAGE_DIRECTORY = "nipkg"
+
+   private static final String CONTROL_FILE_NAME = "control"
+   private static final String INSTRUCTIONS_FILE_NAME = "instructions"
+   private static final String CONTROL_DIRECTORY = "control"
+   private static final String DATA_DIRECTORY = "data"
+
+   def installDestination
+
+   Nipkg(script, packageInfo) {
+      super(script, packageInfo)
+      this.installDestination = packageInfo.get('install_destination')
    }
 
-   void buildPackage() {
-      def packageInfo = """
-         Building package $name from $payloadDir
-         Package version: $pkgVersion
-         Description: $description
-         Homepage: $homepage
-         Display name: $displayName
-         Eula dependency: $eulaDependency
-         Dependencies: $dependencies
-         """.stripIndent()
+   void buildPackage(lvVersion) {
+      stageFiles(lvVersion)
       
-      script.echo packageInfo
+      def nipkgOutput = script.nipkgBuild(PACKAGE_DIRECTORY, PACKAGE_DIRECTORY)
+      script.copyFiles(PACKAGE_DIRECTORY, "\"$payloadDir\\installer\"", nipkgOutput)
+   }
+
+   private void stageFiles(lvVersion) {
+      if(!script.fileExists(PACKAGE_DIRECTORY)) {
+         script.bat "mkdir \"$PACKAGE_DIRECTORY\\$CONTROL_DIRECTORY\" \"$PACKAGE_DIRECTORY\\$DATA_DIRECTORY\""
+      }
+
+      createDebianFile()
+      updateControlFile(lvVersion)
+      updateInstructionsFile(lvVersion)
+
+      stagePayload(lvVersion)
+   }
+
+   private void updateControlFile(lvVersion) {
+      updateBuildFile(CONTROL_FILE_NAME, CONTROL_DIRECTORY, lvVersion)
+   }
+
+   private void updateInstructionsFile(lvVersion) {
+      updateBuildFile(INSTRUCTIONS_FILE_NAME, DATA_DIRECTORY, lvVersion)
+   }
+
+   private void updateBuildFile(fileName, destination, lvVersion) {
+      if(!script.fileExists(fileName)) {
+         return
+      }
+
+      def fileText = script.readFile(fileName)
+      def updatedText = updateVersionVariables(fileText, lvVersion)
+
+      script.writeFile file: "$PACKAGE_DIRECTORY\\$destination\\$fileName", text: updatedText
+   }
+
+   private def getBaseVersion() {
+      // This is a workaround for building packages on master until we implement
+      // automatic merging to release branches. Once automatic merges happen,
+      // we will only need to build release- or hotfix- branch packages.
+      if(script.env.BRANCH_NAME == "master") {
+         return "0.0.1"
+      }
+
+      def baseVersion = script.env.BRANCH_NAME.tokenize('-')[1]
+      def versionPartCount = baseVersion.tokenize(".").size()
+
+      def versionPartsToDisplay = 3
+      for(versionPartCount; versionPartCount < versionPartsToDisplay; versionPartCount++) {
+         baseVersion = "${baseVersion}.0"
+      }
+
+      return baseVersion
+   }
+
+   private String updateVersionVariables(text, lvVersion) {
+      def baseVersion = getBaseVersion()
+      def fullVersion = "${baseVersion}.${script.currentBuild.number}+000"
+
+      def replacements = ['nipkg_version': fullVersion, 'display_version': baseVersion]
+      script.versionReplacementExpressions().each { expression ->
+         replacements."$expression" = lvVersion
+      }
+
+      def updatedText = text
+      replacements.each {expression, value ->
+         updatedText = updatedText.replaceAll("\\{$expression\\}", value)
+      }
+
+      return updatedText
+   }
+
+   private void stagePayload(lvVersion) {
+      def destination = updateVersionVariables(installDestination, lvVersion)
+      script.copyFiles(payloadDir, "$PACKAGE_DIRECTORY\\$DATA_DIRECTORY\\$destination")
+   }
+
+   private void createDebianFile() {
+      script.writeFile file: "$PACKAGE_DIRECTORY\\debian-binary", text: "2.0\n"
    }
 }

--- a/src/ni/vsbuild/packages/Nipkg.groovy
+++ b/src/ni/vsbuild/packages/Nipkg.groovy
@@ -23,7 +23,7 @@ class Nipkg extends AbstractPackage {
       script.copyFiles(PACKAGE_DIRECTORY, "\"$payloadDir\\installer\"", nipkgOutput)
    }
 
-   // This method is responsbile for setting up the directory and file
+   // This method is responsible for setting up the directory and file
    // structure required to build a File Package using nipkg.exe.
    // The structure is defined at the following link.
    // http://www.ni.com/documentation/en/ni-package-manager/18.5/manual/assemble-file-package/

--- a/src/ni/vsbuild/packages/PackageFactory.groovy
+++ b/src/ni/vsbuild/packages/PackageFactory.groovy
@@ -2,11 +2,11 @@ package ni.vsbuild.packages
 
 class PackageFactory implements Serializable {
 
-   static Buildable createPackage(script, packageInfo, payloadDir) {
+   static Buildable createPackage(script, packageInfo) {
       def type = packageInfo.get('type')
 
       if(type == 'nipkg') {
-         return new Nipkg(script, packageInfo, payloadDir)
+         return new Nipkg(script, packageInfo)
       }
 
       script.failBuild("\'$type\' is an invalid package type.")

--- a/src/ni/vsbuild/stages/Archive.groovy
+++ b/src/ni/vsbuild/stages/Archive.groovy
@@ -20,7 +20,7 @@ class Archive extends AbstractStage {
          buildOutputDir = BuildConfiguration.STAGING_DIR
       }
 
-      script.bat "xcopy \"$buildOutputDir\" \"$archiveLocation\\$lvVersion\" /e /i"
+      script.copyFiles(buildOutputDir, "$archiveLocation\\$lvVersion")
 
       setArchiveVar()
    }

--- a/src/ni/vsbuild/stages/Package.groovy
+++ b/src/ni/vsbuild/stages/Package.groovy
@@ -10,7 +10,7 @@ class Package extends AbstractStage {
    }
 
    void executeStage() {
-      Buildable pkg = PackageFactory.createPackage(script, configuration.packageInfo, configuration.archive.get('build_output_dir'))
-      pkg.build()
+      Buildable pkg = PackageFactory.createPackage(script, configuration.packageInfo)
+      pkg.build(lvVersion)
    }
 }

--- a/vars/buildSetup.groovy
+++ b/vars/buildSetup.groovy
@@ -1,6 +1,5 @@
 def call(lvVersion) {
-   def programFiles = bat returnStdout: true, script: "echo off & set PROGRAMFILES(x86) & echo on"
-   programFiles = programFiles.split('=')[1].trim()
+   def programFiles = getWindowsVar("PROGRAMFILES(x86)")
    env."labviewPath_${lvVersion}" = "$programFiles\\National Instruments\\LabVIEW ${lvVersion}\\LabVIEW.exe"
    bat "niveristand-custom-device-build-tools\\resources\\buildSetup.bat"
 }

--- a/vars/copyFiles.groovy
+++ b/vars/copyFiles.groovy
@@ -1,15 +1,19 @@
 def call(sourceDirectory, destinationDirectory, files=null) {
    def copyCommand = "robocopy \"$sourceDirectory\" \"$destinationDirectory\""
+
+   // These switches are for console output suppression so we don't get a bunch of junk
+   // in our logs
+   // https://ss64.com/nt/robocopy.html
    def commandSwitches = "/NFL /NDL /NJH /NJS /nc /ns /np"
-   
+
    // If the files argument is not passed, mirror the entire source to destination
-   if(!files  || files == null) {
+   if(!files || files == null) {
       commandSwitches = "$commandSwitches /MIR"
    }
    else {
       copyCommand = "$copyCommand \"$files\""
    }
-   
+
    // robocopy uses multiple return codes for success
    // https://ss64.com/nt/robocopy-exit.html
    bat "($copyCommand $commandSwitches) ^& IF %ERRORLEVEL% LSS 8 SET ERRORLEVEL=0"

--- a/vars/copyFiles.groovy
+++ b/vars/copyFiles.groovy
@@ -1,0 +1,16 @@
+def call(sourceDirectory, destinationDirectory, files=null) {
+   def copyCommand = "robocopy \"$sourceDirectory\" \"$destinationDirectory\""
+   def commandSwitches = "/NFL /NDL /NJH /NJS /nc /ns /np"
+   
+   // If the files argument is not passed, mirror the entire source to destination
+   if(!files  || files == null) {
+      commandSwitches = "$commandSwitches /MIR"
+   }
+   else {
+      copyCommand = "$copyCommand \"$files\""
+   }
+   
+   // robocopy uses multiple return codes for success
+   // https://ss64.com/nt/robocopy-exit.html
+   bat "($copyCommand $commandSwitches) ^& IF %ERRORLEVEL% LSS 8 SET ERRORLEVEL=0"
+}

--- a/vars/getWindowsVar.groovy
+++ b/vars/getWindowsVar.groovy
@@ -1,0 +1,9 @@
+// The bat command always returns the full command as well as the output
+// when returnStdout is true. To get the actual value, trim the leading and 
+// trailing whitespace, split the text to separate the command and the stdout
+// value and finally index the split list.
+def call(var) {
+   def commandOutput = bat returnStdout: true, script: "echo off & echo %${var}% & echo on"
+   def value = commandOutput.trim().split("\n")[1]
+   return value
+}

--- a/vars/nipkgBuild.groovy
+++ b/vars/nipkgBuild.groovy
@@ -1,0 +1,12 @@
+def call(source, destination){
+   def programFiles = bat returnStdout: true, script: "echo off & set PROGRAMFILES & echo on"
+   programFiles = programFiles.split('=')[1].trim()
+   programFiles = programFiles.split("\n")[0]
+   
+   def nipkgExePath = "$programFiles\\National Instruments\\NI Package Manager\\nipkg.exe"
+   bat "\"$nipkgExePath\" pack \"$source\" \"$destination\""
+   
+   def nipkgOutput = bat returnStdout: true, script: "echo off & dir \"$destination\\*.nipkg\" /B & echo on"
+   nipkgOutput = (nipkgOutput =~ /[\w\-\+\.]+.nipkg/)[0]
+   return nipkgOutput.trim()
+}

--- a/vars/nipkgBuild.groovy
+++ b/vars/nipkgBuild.groovy
@@ -1,11 +1,10 @@
 def call(source, destination){
-   def programFiles = bat returnStdout: true, script: "echo off & set PROGRAMFILES & echo on"
-   programFiles = programFiles.split('=')[1].trim()
-   programFiles = programFiles.split("\n")[0]
-   
+   def programFiles = getWindowsVar("PROGRAMFILES")
+
+   // http://www.ni.com/documentation/en/ni-package-manager/18.5/manual/build-package-using-cli/
    def nipkgExePath = "$programFiles\\National Instruments\\NI Package Manager\\nipkg.exe"
    bat "\"$nipkgExePath\" pack \"$source\" \"$destination\""
-   
+
    def nipkgOutput = bat returnStdout: true, script: "echo off & dir \"$destination\\*.nipkg\" /B & echo on"
    nipkgOutput = (nipkgOutput =~ /[\w\-\+\.]+.nipkg/)[0]
    return nipkgOutput.trim()

--- a/vars/versionReplacementExpressions.groovy
+++ b/vars/versionReplacementExpressions.groovy
@@ -1,0 +1,3 @@
+def call(){
+   return ['labview_version', 'veristand_version']
+}


### PR DESCRIPTION
- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-custom-device-build-tools/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Enables building nipkg installers as part of the build pipeline.

### Why should this Pull Request be merged?

We want to test the binaries that we would actually ship. This change enables us to test the actual installers that would be used in VeriStand systems.

### What testing has been done?

[Builds](http://coordinator/job/VeriStand/job/buckd/job/testbuild/) of branches master, release-18.1 and dev/package-build. Only master and release build nipkg installers and dev branches do not. Repos using the build tools still need to be updated with control files and new build.toml information to use the enhancements in this change.
