### PR TITLE
Allow build.toml to specify a version-specific install location

### DIFF
--- a/src/ni/vsbuild/packages/AbstractPackage.groovy
+++ b/src/ni/vsbuild/packages/AbstractPackage.groovy
@@ -5,19 +5,21 @@ abstract class AbstractPackage implements Buildable {
    def script
    def type
    def payloadDir
+   def lvVersion
 
-   AbstractPackage(script, packageInfo) {
+   AbstractPackage(script, packageInfo, lvVersion) {
       this.script = script
+      this.lvVersion = lvVersion
       this.type = packageInfo.get('type')
       this.payloadDir = packageInfo.get('payload_dir')
    }
 
-   void build(lvVersion) {
+   void build() {
       script.echo "Building $type package..."
-      buildPackage(lvVersion)
+      buildPackage()
       script.echo "$type package built."
    }
 
-   abstract void buildPackage(lvVersion)
+   abstract void buildPackage()
 
 }

--- a/src/ni/vsbuild/packages/Buildable.groovy
+++ b/src/ni/vsbuild/packages/Buildable.groovy
@@ -2,6 +2,6 @@ package ni.vsbuild.packages
 
 interface Buildable extends Serializable {
 
-   void build(lvVersion)
+   void build()
 
 }

--- a/src/ni/vsbuild/packages/PackageFactory.groovy
+++ b/src/ni/vsbuild/packages/PackageFactory.groovy
@@ -2,11 +2,11 @@ package ni.vsbuild.packages
 
 class PackageFactory implements Serializable {
 
-   static Buildable createPackage(script, packageInfo) {
+   static Buildable createPackage(script, packageInfo, lvVersion) {
       def type = packageInfo.get('type')
 
       if(type == 'nipkg') {
-         return new Nipkg(script, packageInfo)
+         return new Nipkg(script, packageInfo, lvVersion)
       }
 
       script.failBuild("\'$type\' is an invalid package type.")

--- a/src/ni/vsbuild/stages/Package.groovy
+++ b/src/ni/vsbuild/stages/Package.groovy
@@ -10,7 +10,7 @@ class Package extends AbstractStage {
    }
 
    void executeStage() {
-      Buildable pkg = PackageFactory.createPackage(script, configuration.packageInfo)
-      pkg.build(lvVersion)
+      Buildable pkg = PackageFactory.createPackage(script, configuration.packageInfo, lvVersion)
+      pkg.build()
    }
 }


### PR DESCRIPTION
- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-custom-device-build-tools/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Enables nipkgs to specify different install locations based on LabVIEW/VeriStand version.

### Why should this Pull Request be merged?

The SLSC custom devices install to different locations between VS 2016 and VS 2017. This allows a single build.toml file to specify which install location should be used.

### What testing has been done?

Built the EDS custom device for 2018 and 2016. The package contents are staged to different locations as specified in the build.toml file.
