### PR TITLE
Make diff images collapsible

### DIFF
--- a/resources/post_pictures_to_pull_request.py
+++ b/resources/post_pictures_to_pull_request.py
@@ -37,7 +37,7 @@ def _post_file(file_data, folder, file_name, header, picRepo):
 
 
 def _post_comment_to_pr(urlPicPairs, diffFailures, pullRequestInfo, prNumber, header):
-    formatString = "### %s:\n ![capture](%s)\n\n"
+    formatString = "<details><summary><b>%s</b></summary>\n\n![capture](%s)</details>\n\n"
     body = """Bleep bloop!
 
 LabVIEW Diff Robot here with some diffs served up hot for your pull request.


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-custom-device-build-tools/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Make images posted by the diff bot be collapsible, so they can be expanded individually without taking up too much screen space.

### Why should this Pull Request be merged?

Having all of the images open by default is unwieldy.

### What testing has been done?

Test diff: https://github.com/rtzoeller/niveristand-chassis-timesync-custom-device/pull/4