### PR TITLE
The diff bot should manage its own dependencies and fail silently on timeout

### DIFF
--- a/vars/diffPipeline.groovy
+++ b/vars/diffPipeline.groovy
@@ -1,36 +1,56 @@
 #!/usr/bin/env groovy
 
+import org.jenkinsci.plugins.workflow.steps.FlowInterruptedException
+import hudson.AbortException
+
 //note: this script assumes that it will be invoked from another script after that script has defined the necessary parameters
 
 //This script further assumes that Jenkins is configured (via the Pipeline Shared Libraries plugin) to implicitly include https://github.com/ni/niveristand-custom-device-build-tools
 
 def call(lvVersion) {
-   if (env.CHANGE_ID) {
-      node(lvVersion) {
-         echo 'Starting build...'
-         stage('Pre-Clean') {
-            deleteDir()
-         }
-         stage('SCM_Checkout') {
-            echo 'Attempting to get source from repo...'
-            timeout(time: 5, unit: 'MINUTES') {
-               checkout scm
-            }
+   // Skip diffing for build which aren't pull-requests.
+   // Only pull-requests will have the change ID set.
+   if (!env.CHANGE_ID) {
+      return
+   }
 
-            timeout(time: 5, unit: 'MINUTES') {
-               cloneBuildTools()
-            }
+   node(lvVersion) {
+      echo 'Starting build...'
+      stage('Pre-Clean') {
+         deleteDir()
+      }
+      stage('SCM_Checkout') {
+         echo 'Attempting to get source from repo...'
+         timeout(time: 5, unit: 'MINUTES') {
+            checkout scm
          }
-         // If this change is a pull request, diff vis.
-         stage('Diff VIs') {
+
+         timeout(time: 5, unit: 'MINUTES') {
+            cloneBuildTools()
+         }
+      }
+      // If this change is a pull request, diff vis.
+      stage('Diff VIs') {
+         try {
             timeout(time: 60, unit: 'MINUTES') {
                lvDiff(lvVersion, env.DIFFING_PIC_REPO, env.GITHUB_DIFF_TOKEN)
                echo 'Diff Succeeded!'
             }
+         } catch (FlowInterruptedException | AbortException e) {
+            // We would expect to get a FlowInterruptedException if the timeout occurs.
+            // However this is only true some of the time - depending on how Jenkins
+            // kills the processes, we may get an AbortException from the killed process.
+            // There is no good common ancestor to catch, so we catch both explicitly.
+
+            // There is currently (2/7/19) not a way to have a stage report
+            // failure but have the pipeline report success. We could mark
+            // the build as unstable, but that causes GitHub report a failure.
+            // We will allow the diff to fail semi-silently since the build itself succeeded.
+            print "Diffing VIs failed due to timeout"
          }
-         stage('Cleanup') {
-            deleteDir()
-         }
+      }
+      stage('Cleanup') {
+         deleteDir()
       }
    }
 }

--- a/vars/lvDiff.groovy
+++ b/vars/lvDiff.groovy
@@ -4,10 +4,27 @@ def call(lvVersion, diffingPicRepo, githubDiffToken) {
    echo 'Running LabVIEW diff build between origin/master and this commit'
    def diffDir = "${WORKSPACE}\\diff_dir"
    def resourcesDir = "${WORKSPACE}\\niveristand-custom-device-build-tools\\resources"
-   bat "if exist ${diffDir} rd /s /q ${diffDir}"
+   bat "if exist ${diffDir} rmdir /s /q ${diffDir}"
    bat "mkdir ${diffDir}"
-   bat "python -u \"${resourcesDir}/labview_diff.py\" \"${WORKSPACE}\" \"${diffDir}\" ${lvVersion} --target=origin/master"
-   // Silencing echo so as to not print out the token.
-   bat "@python -u \"${resourcesDir}/github_commenter.py\" --token=\"${githubDiffToken}\" --pic-dir=\"${diffDir}\" --pull-req=\"${CHANGE_ID}\" --info=\"${JOB_NAME}\" --pic-repo=\"${diffingPicRepo}\""
+
+   // We can't source a Python virtualenv in one call and use it in another,
+   // because Groovy will spawn a separate shell for each call.
+   // Instead, build a multi-line string and execute it all at once.
+   // We silence echo in some calls so as to not print out the token.
+   def venvDir = "env"
+   bat """
+      pip install virtualenv
+      virtualenv ${venvDir}
+      call ${venvDir}\\Scripts\\activate.bat
+      
+      pip install requests
+      
+      python -u "${resourcesDir}/labview_diff.py" "${WORKSPACE}" "${diffDir}" ${lvVersion} --target=origin/master
+      @python -u "${resourcesDir}/github_commenter.py" --token="${githubDiffToken}" --pic-dir="${diffDir}" --pull-req="${CHANGE_ID}" --info="${JOB_NAME}" --pic-repo="${diffingPicRepo}"
+      
+      call ${venvDir}\\Scripts\\deactivate.bat
+      rmdir /s /q ${venvDir}
+   """
+
    lvCloseLabVIEW()
 }


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-custom-device-build-tools/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

- The diff bot should install its own dependencies in a virtualenv, so that it does not require additional software to be installed on the build machine
- The diff bot timing out should not break the build

### Why should this Pull Request be merged?

The dependencies changes get the diff bot working on the new build nodes, and the 

### What testing has been done?

Build where the diff bot does not time out: http://coordinator/job/VeriStand/job/rtzoeller/job/niveristand-chassis-timesync-custom-device/view/change-requests/job/PR-5/25/console

Build where the diff bot times out: http://coordinator/job/VeriStand/job/rtzoeller/job/niveristand-chassis-timesync-custom-device/view/change-requests/job/PR-5/26/console
