### PR TITLE
Ignore modifications present on the target branch when diffing

### DIFF
--- a/resources/labview_diff.py
+++ b/resources/labview_diff.py
@@ -90,7 +90,7 @@ def get_changed_labview_files(target_ref):
     :param target_ref: The git ref to check for changed files against
     :return: Tuples of the form (status, filename) where status is either "A" or "M", depending on whether the file was added or modified.
     """
-    diff_args = ["git", "diff", "--name-status", "--diff-filter=AM", target_ref, "HEAD"]
+    diff_args = ["git", "diff", "--name-status", "--diff-filter=AM", target_ref + "...", "HEAD"]
     diff_output = subprocess.check_output(diff_args).decode("utf-8")
 
     # https://regex101.com/r/EFVDVV/1


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-custom-device-build-tools/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Reduce the VIs being diffed to only the ones modified in the current pull request.

Previously we looked at all VIs which had been modified between the pull request and master. This unintentionally included any VIs which had been changed on master (i.e. another pull request had been submitted) but not on the pull request branch.

### Why should this Pull Request be merged?

We are diffing VIs which the current pull request did not modify.

### What testing has been done?

Running the git command by hand to see what files it lists as modified.
