### PR TITLE
Add manifest file for build setup

### DIFF
--- a/docs/Toml Help.md
+++ b/docs/Toml Help.md
@@ -278,22 +278,28 @@ To define steps to execute during build, include a steps array in the build tabl
 Most often, this stage will contain one or more of the lvBuild* steps. If there are no steps in `[[build.steps]]`, this stage will not be added to the pipeline.
 
 ## Package
-The package stage executes immediately after the build stage. It takes the build output and packages everything into a single file for simple distribution.
+The package stage executes immediately after the build stage. It takes the specified directory and packages everything into a single file for simple distribution.
 
 ### Definition
-To define an archive stage, add a package table to `build.toml`.
+To define a single package stage, add a package table to `build.toml`.
 
 `[package]`
 
+To export multiple package stages, add an array of packages to `build.toml`.
+
+`[[package]]`
+
+`[[package]]`
+
 #### Supported Packages
-The package stage requires a `type` to be defined, although there is currently only one supported type.
+The package stage requires a `type` to be defined. 
 
 Key | Description | Required
 -|-|-
 `type`| file extension of the final package | **YES**
 
 ##### nipkg
-The nipkg package type builds a package the can be installed through NI Package Manager (NIPM). NIPM must be installed on the build machine in order to build this type.
+The nipkg package type builds a package that can be installed through NI Package Manager (NIPM). NIPM must be installed on the build machine in order to build this type.
 
 ###### Suported Keys
 Key | Description | Required
@@ -311,8 +317,27 @@ install_destination = 'documents\National Instruments\NI VeriStand {veristand_ve
 2016_install_destination = 'documents\\National Instruments\\NI VeriStand {veristand_version}\\Custom Devices\\SLSC Plug-ins'
 ```
 
+---
+
+##### zip
+
+The zip package type builds a compressed package that can be installed using ZIP decompression utilities. Most operating systems natively support inflating a compressed ZIP file.
+
+###### Suported Keys
+Key | Description | Required
+-|-|-
+`payload_dir` | location of files to be compressed and packaged | **YES**
+
+###### Example
+```
+[[package]]
+type = 'zip'
+payload_dir = 'Source'
+```
+
 ### Notes
 If no package stage is defined in `build.toml` this stage will not be added to the pipeline. If a package stage is defined, an archive stage must also be defined.
+---
 
 ## Archive
 The archive stage executes immediately after the package stage. During this stage, the output of the build and package stages is copied to a more permanent location so it can be consumed later.

--- a/src/ni/vsbuild/Pipeline.groovy
+++ b/src/ni/vsbuild/Pipeline.groovy
@@ -31,12 +31,12 @@ class Pipeline implements Serializable {
          stages << new Build(script, buildConfiguration, lvVersion)
       }
 
-      def withArchiveStage() {
-         stages << new Archive(script, buildConfiguration, lvVersion)
-      }
-
       def withPackageStage() {
          stages << new Package(script, buildConfiguration, lvVersion)
+      }
+
+      def withArchiveStage() {
+         stages << new Archive(script, buildConfiguration, lvVersion)
       }
 
       // The plan is to enable automatic merging from master to

--- a/src/ni/vsbuild/Pipeline.groovy
+++ b/src/ni/vsbuild/Pipeline.groovy
@@ -122,16 +122,23 @@ class Pipeline implements Serializable {
    }
 
    private void setup(lvVersion) {
+      def manifest = script.readJSON text: '{}'
+
       script.stage("Checkout_$lvVersion") {
          script.deleteDir()
          script.echo 'Attempting to get source from repo.'
          script.timeout(time: 5, unit: 'MINUTES'){
-            script.checkout(script.scm)
+            manifest['scm'] = script.checkout(script.scm)
          }
       }
       script.stage("Setup_$lvVersion") {
          script.cloneBuildTools()
          script.buildSetup(lvVersion)
+
+         // Write a manifest
+         def file = 'Built/installer/manifest.json'
+         script.echo "Writing manifest to $file"
+         script.writeJSON file: file, json: manifest, pretty: 3
       }
    }
 }

--- a/src/ni/vsbuild/packages/AbstractPackage.groovy
+++ b/src/ni/vsbuild/packages/AbstractPackage.groovy
@@ -35,9 +35,9 @@ abstract class AbstractPackage implements Buildable {
    }
 
    protected def getFullVersion() {
-       def baseVersion = getBaseVersion()
-       def fullVersion = "${baseVersion}.${script.currentBuild.number}"
+      def baseVersion = getBaseVersion()
+      def fullVersion = "${baseVersion}.${script.currentBuild.number}"
 
-       return fullVersion
+      return fullVersion
    }
 }

--- a/src/ni/vsbuild/packages/AbstractPackage.groovy
+++ b/src/ni/vsbuild/packages/AbstractPackage.groovy
@@ -22,4 +22,22 @@ abstract class AbstractPackage implements Buildable {
 
    abstract void buildPackage()
 
+   protected def getBaseVersion() {
+      def baseVersion = script.env.BRANCH_NAME.split("[-/]")[1]
+      def versionPartCount = baseVersion.tokenize(".").size()
+
+      def versionPartsToDisplay = 3
+      for(versionPartCount; versionPartCount < versionPartsToDisplay; versionPartCount++) {
+         baseVersion = "${baseVersion}.0"
+      }
+
+      return baseVersion
+   }
+
+   protected def getFullVersion() {
+       def baseVersion = getBaseVersion()
+       def fullVersion = "${baseVersion}.${script.currentBuild.number}"
+
+       return fullVersion
+   }
 }

--- a/src/ni/vsbuild/packages/Nipkg.groovy
+++ b/src/ni/vsbuild/packages/Nipkg.groovy
@@ -75,21 +75,9 @@ class Nipkg extends AbstractPackage {
    // for any other branches, including master. The version must
    // be appended to the release or hotfix branch name after a
    // dash (-) or slash (/).
-   private def getBaseVersion() {
-      def baseVersion = script.env.BRANCH_NAME.split("[-/]")[1]
-      def versionPartCount = baseVersion.tokenize(".").size()
-
-      def versionPartsToDisplay = 3
-      for(versionPartCount; versionPartCount < versionPartsToDisplay; versionPartCount++) {
-         baseVersion = "${baseVersion}.0"
-      }
-
-      return baseVersion
-   }
-
    private String updateVersionVariables(text) {
       def baseVersion = getBaseVersion()
-      def fullVersion = "${baseVersion}.${script.currentBuild.number}+000"
+      def fullVersion = getFullVersion()
 
       def replacements = ['nipkg_version': fullVersion, 'display_version': baseVersion]
       script.versionReplacementExpressions().each { expression ->

--- a/src/ni/vsbuild/packages/PackageFactory.groovy
+++ b/src/ni/vsbuild/packages/PackageFactory.groovy
@@ -9,7 +9,7 @@ class PackageFactory implements Serializable {
          return new Nipkg(script, packageInfo, lvVersion)
       }
       else if(type == 'zip') {
-          return new Zip(script, packageInfo, lvVersion)
+         return new Zip(script, packageInfo, lvVersion)
       }
 
       script.failBuild("\'$type\' is an invalid package type.")

--- a/src/ni/vsbuild/packages/PackageFactory.groovy
+++ b/src/ni/vsbuild/packages/PackageFactory.groovy
@@ -8,6 +8,9 @@ class PackageFactory implements Serializable {
       if(type == 'nipkg') {
          return new Nipkg(script, packageInfo, lvVersion)
       }
+      else if(type == 'zip') {
+          return new Zip(script, packageInfo, lvVersion)
+      }
 
       script.failBuild("\'$type\' is an invalid package type.")
    }

--- a/src/ni/vsbuild/packages/Zip.groovy
+++ b/src/ni/vsbuild/packages/Zip.groovy
@@ -2,13 +2,18 @@ package ni.vsbuild.packages
 
 class Zip extends AbstractPackage {
 
+    private static final String INSTALLER_DIRECTORY = "installer"
+
    Zip(script, packageInfo, lvVersion) {
       super(script, packageInfo, lvVersion)
    }
 
    void buildPackage() {
-       // zip -r <name of package file> <folder>
-       script.echo "Zipping the thingies"
+        def componentParts = script.getComponentParts()
+        def repoName = componentParts['repo']
+        def fullVersion = getFullVersion()
+        def destination = "$INSTALLER_DIRECTORY\\${repoName}_${payloadDir}_${fullversion}.zip"
+        script.zipBuild(payloadDir, destination);
    }
 }
 

--- a/src/ni/vsbuild/packages/Zip.groovy
+++ b/src/ni/vsbuild/packages/Zip.groovy
@@ -1,0 +1,14 @@
+package ni.vsbuild.packages
+
+class Zip extends AbstractPackage {
+
+   Zip(script, packageInfo, lvVersion) {
+      super(script, packageInfo, lvVersion)
+   }
+
+   void buildPackage() {
+       // zip -r <name of package file> <folder>
+       script.echo "Zipping the thingies"
+   }
+}
+

--- a/src/ni/vsbuild/packages/Zip.groovy
+++ b/src/ni/vsbuild/packages/Zip.groovy
@@ -2,7 +2,7 @@ package ni.vsbuild.packages
 
 class Zip extends AbstractPackage {
 
-    private static final String INSTALLER_DIRECTORY = "installer"
+    private static final String INSTALLER_DIRECTORY = "Built\\installer"
 
    Zip(script, packageInfo, lvVersion) {
       super(script, packageInfo, lvVersion)
@@ -12,7 +12,7 @@ class Zip extends AbstractPackage {
         def componentParts = script.getComponentParts()
         def repoName = componentParts['repo']
         def fullVersion = getFullVersion()
-        def destination = "$INSTALLER_DIRECTORY\\${repoName}_${payloadDir}_${fullversion}.zip"
+        def destination = "$INSTALLER_DIRECTORY\\${repoName}_${payloadDir}_${fullVersion}.zip"
         script.zipBuild(payloadDir, destination);
    }
 }

--- a/src/ni/vsbuild/packages/Zip.groovy
+++ b/src/ni/vsbuild/packages/Zip.groovy
@@ -2,18 +2,17 @@ package ni.vsbuild.packages
 
 class Zip extends AbstractPackage {
 
-    private static final String INSTALLER_DIRECTORY = "Built\\installer"
+   private static final String INSTALLER_DIRECTORY = "Built\\installer"
 
    Zip(script, packageInfo, lvVersion) {
       super(script, packageInfo, lvVersion)
    }
 
    void buildPackage() {
-        def componentParts = script.getComponentParts()
-        def repoName = componentParts['repo']
-        def fullVersion = getFullVersion()
-        def destination = "$INSTALLER_DIRECTORY\\${repoName}_${payloadDir}_${fullVersion}.zip"
-        script.zipBuild(payloadDir, destination);
+      def componentParts = script.getComponentParts()
+      def repoName = componentParts['repo']
+      def fullVersion = getFullVersion()
+      def destination = "$INSTALLER_DIRECTORY\\${repoName}_${payloadDir}_${fullVersion}.zip"
+      script.zipBuild(payloadDir, destination);
    }
 }
-

--- a/src/ni/vsbuild/stages/Package.groovy
+++ b/src/ni/vsbuild/stages/Package.groovy
@@ -22,8 +22,8 @@ class Package extends AbstractStage {
       }
 
       for (def packageInfo : packageInfoCollection) {
-         Buildable package = PackageFactory.createPackage(script, packageInfo, lvVersion)
-         package.build()
+         Buildable pkg = PackageFactory.createPackage(script, packageInfo, lvVersion)
+         pkg.build()
       }
    }
 }

--- a/src/ni/vsbuild/stages/Package.groovy
+++ b/src/ni/vsbuild/stages/Package.groovy
@@ -12,9 +12,9 @@ class Package extends AbstractStage {
    void executeStage() {
       def packageInfoCollection = []
 
-      // Developers can specify a single package [Package] or multiple packages [[Package]].
+      // Developers can specify a single package [Package] or a collection of packages [[Package]].
       // Test the package information parameter and iterate as needed.
-      if (configuration.packageInfo instanceof Collection) {
+      if (configuration.packageInfo in Collection) {
          packageInfoCollection = configuration.packageInfo
       }
       else {

--- a/src/ni/vsbuild/stages/Package.groovy
+++ b/src/ni/vsbuild/stages/Package.groovy
@@ -10,9 +10,20 @@ class Package extends AbstractStage {
    }
 
    void executeStage() {
-       for(def packageInfo : configuration.packageInfo) {
-            Buildable pkg = PackageFactory.createPackage(script, packageInfo, lvVersion)
-            pkg.build()
-       }
-    }
+      def packageInfoCollection = []
+
+      // Developers can specify a single package [Package] or multiple packages [[Package]].
+      // Test the package information parameter and iterate as needed.
+      if (configuration.packageInfo instanceof Collection) {
+         packageInfoCollection = configuration.packageInfo
+      }
+      else {
+         packageInfoCollection.add(configuration.packageInfo)
+      }
+
+      for (def packageInfo : packageInfoCollection) {
+         Buildable package = PackageFactory.createPackage(script, packageInfo, lvVersion)
+         package.build()
+      }
+   }
 }

--- a/src/ni/vsbuild/stages/Package.groovy
+++ b/src/ni/vsbuild/stages/Package.groovy
@@ -10,7 +10,9 @@ class Package extends AbstractStage {
    }
 
    void executeStage() {
-      Buildable pkg = PackageFactory.createPackage(script, configuration.packageInfo, lvVersion)
-      pkg.build()
-   }
+       for(def packageInfo : configuration.packageInfo) {
+            Buildable pkg = PackageFactory.createPackage(script, packageInfo, lvVersion)
+            pkg.build()
+       }
+    }
 }

--- a/vars/zipBuild.groovy
+++ b/vars/zipBuild.groovy
@@ -1,7 +1,7 @@
 def call(source, destination){
-    echo "Zipping $source folder to $destination"
+   echo "Zipping $source folder to $destination"
 
-    zip dir: source, glob: '', zipFile: destination
+   zip dir: source, glob: '', zipFile: destination
 
-    return destination
+   return destination
 }

--- a/vars/zipBuild.groovy
+++ b/vars/zipBuild.groovy
@@ -1,7 +1,7 @@
 def call(source, destination){
     echo "Zipping $source folder to $destination"
 
-    zip dir: "\"$source\"", glob: '', zipFile: "\"$destination\""
+    zip dir: source, glob: '', zipFile: destination
 
     return destination
 }

--- a/vars/zipBuild.groovy
+++ b/vars/zipBuild.groovy
@@ -1,0 +1,7 @@
+def call(source, destination){
+    echo "Zipping $source folder to $destination"
+
+    zip dir: "\"$source\"", glob: '', zipFile: "\"$destination\""
+
+    return destination
+}


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-custom-device-build-tools/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

This PR adds a new manifest file, manifest.json, which is exported alongside the packages. The manifest currently contains GIT variables used for the build. In the future we can extend this manifest to include the LabVIEW versions and toolkits used to build the custom devices.

### Why should this Pull Request be merged?

We need the commit information to find the tests associated with a specific export. This will be used by the automated test system to exercise the system tests once the installers are built.

### What testing has been done?

I created a private export from my personal repository which produced [this manifest](https://github.com/ni/niveristand-custom-device-build-tools/files/2886358/manifest.json.txt)



