### PR TITLE
Add manifest file for build setup. Track SCM and other variables as n…

### DIFF
--- a/src/ni/vsbuild/Pipeline.groovy
+++ b/src/ni/vsbuild/Pipeline.groovy
@@ -122,16 +122,23 @@ class Pipeline implements Serializable {
    }
 
    private void setup(lvVersion) {
+      def manifest = script.readJSON text: '{}'
+
       script.stage("Checkout_$lvVersion") {
          script.deleteDir()
          script.echo 'Attempting to get source from repo.'
          script.timeout(time: 5, unit: 'MINUTES'){
-            script.checkout(script.scm)
+            manifest['scm'] = script.checkout(script.scm)
          }
       }
       script.stage("Setup_$lvVersion") {
          script.cloneBuildTools()
          script.buildSetup(lvVersion)
+
+         // Write a manifest
+         def file = 'Built/installer/manifest.json'
+         script.echo "Writing manifest to $file"
+         script.writeJSON file: file, json: manifest, pretty: 3
       }
    }
 }

--- a/src/ni/vsbuild/Pipeline.groovy
+++ b/src/ni/vsbuild/Pipeline.groovy
@@ -6,6 +6,8 @@ class Pipeline implements Serializable {
 
    private static final String JSON_FILE = 'build.json'
 
+   private static final String MANIFEST_FILE = 'Built/installer/manifest.json'
+
    def script
    PipelineInformation pipelineInformation
    def stages = []
@@ -136,9 +138,8 @@ class Pipeline implements Serializable {
          script.buildSetup(lvVersion)
 
          // Write a manifest
-         def file = 'Built/installer/manifest.json'
-         script.echo "Writing manifest to $file"
-         script.writeJSON file: file, json: manifest, pretty: 3
+         script.echo "Writing manifest to $MANIFEST_FILE"
+         script.writeJSON file: MANIFEST_FILE, json: manifest, pretty: 3
       }
    }
 }


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-custom-device-build-tools/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

This PR adds a new manifest file, manifest.json, which is exported alongside the packages. The manifest currently contains GIT variables used for the build. In the future we can extend this manifest to include the LabVIEW versions and toolkits used to build the custom devices.

### Why should this Pull Request be merged?

We need the commit information to find the tests associated with a specific export. This will be used by the automated test system to exercise the system tests once the installers are built.

### What testing has been done?

I created a private export from my personal repository which produced [this manifest](https://github.com/ni/niveristand-custom-device-build-tools/files/2886358/manifest.json.txt)



