### PR TITLE
Replace "/"s in branch names with the URL encoding

### DIFF
--- a/vars/buildDependencies.groovy
+++ b/vars/buildDependencies.groovy
@@ -12,7 +12,8 @@ def call(buildInformation) {
    
    buildInformation.dependencies.each{dependency->
       try {
-         dependencyBuild = build "../$dependency/${env.BRANCH_NAME}"
+         escapedBranchName = "${env.BRANCH_NAME}".replace("/", "%2F")
+         dependencyBuild = build "../$dependency/${escapedBranchName}"
       } catch(AbortException e) {
          // check if there is a job for the current branch name
          if(e.getMessage().startsWith('No item named')) {


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-custom-device-build-tools/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Fixes #35.

### Why should this Pull Request be merged?

We currently fall back to master when trying to build dependencies if the branch name contains a "/". This affects dev and release builds for the SEECD.

### What testing has been done?

Kicked off a build on a dev branch containing a slash, confirmed it chose the correct (non-master) branch. http://coordinator/job/VeriStand/job/ni/job/niveristand-scan-engine-ethercat-custom-device/job/dev%252Fadd_9266/7/console
