### PR TITLE
Override default VeriStand assembly versions

### DIFF
--- a/resources/LabVIEW.exe.config
+++ b/resources/LabVIEW.exe.config
@@ -7,134 +7,134 @@
 			<assemblyIdentity name="NationalInstruments.VeriStand.APIInterface" publicKeyToken="a6d690c380daa308" culture="Neutral" />
 			<!-- Assembly versions can be redirected in application, 
 			  publisher policy, or machine configuration files. -->
-			<bindingRedirect oldVersion="0.0.0.0-2015.1.0.0" newVersion="2016.0.0.0" />
+			<bindingRedirect oldVersion="0.0.0.0-65535.65535.65535.65535" newVersion="2016.0.0.0" />
 		  </dependentAssembly>
 		  <dependentAssembly>
 			<assemblyIdentity name="NationalInstruments.VeriStand.ClientAPI" publicKeyToken="a6d690c380daa308" culture="Neutral" />
 			<!-- Assembly versions can be redirected in application, 
 			  publisher policy, or machine configuration files. -->
-			<bindingRedirect oldVersion="0.0.0.0-2015.1.0.0" newVersion="2016.0.0.0" />
+			<bindingRedirect oldVersion="0.0.0.0-65535.65535.65535.65535" newVersion="2016.0.0.0" />
 		  </dependentAssembly>
 		  <dependentAssembly>
 			<assemblyIdentity name="NationalInstruments.VeriStand" publicKeyToken="a6d690c380daa308" culture="Neutral" />
 			<!-- Assembly versions can be redirected in application, 
 			  publisher policy, or machine configuration files. -->
-			<bindingRedirect oldVersion="0.0.0.0-2015.1.0.0" newVersion="2016.0.0.0" />
+			<bindingRedirect oldVersion="0.0.0.0-65535.65535.65535.65535" newVersion="2016.0.0.0" />
 		  </dependentAssembly>
 		  <dependentAssembly>
 			<assemblyIdentity name="NationalInstruments.VeriStand.Internal" publicKeyToken="a6d690c380daa308" culture="Neutral" />
 			<!-- Assembly versions can be redirected in application, 
 			  publisher policy, or machine configuration files. -->
-			<bindingRedirect oldVersion="0.0.0.0-2015.1.0.0" newVersion="2016.0.0.0" />
+			<bindingRedirect oldVersion="0.0.0.0-65535.65535.65535.65535" newVersion="2016.0.0.0" />
 		  </dependentAssembly>
 		  <dependentAssembly>
 			<assemblyIdentity name="NationalInstruments.VeriStand.SystemDefinitionAPI" publicKeyToken="a6d690c380daa308" culture="Neutral" />
 			<!-- Assembly versions can be redirected in application, 
 			  publisher policy, or machine configuration files. -->
-			<bindingRedirect oldVersion="0.0.0.0-2015.1.0.0" newVersion="2016.0.0.0" />
+			<bindingRedirect oldVersion="0.0.0.0-65535.65535.65535.65535" newVersion="2016.0.0.0" />
 		  </dependentAssembly>
 		  <dependentAssembly>
 			<assemblyIdentity name="NationalInstruments.VeriStand.SystemStorage" publicKeyToken="a6d690c380daa308" culture="Neutral" />
 			<!-- Assembly versions can be redirected in application, 
 			  publisher policy, or machine configuration files. -->
-			<bindingRedirect oldVersion="0.0.0.0-2015.1.0.0" newVersion="2016.0.0.0" />
+			<bindingRedirect oldVersion="0.0.0.0-65535.65535.65535.65535" newVersion="2016.0.0.0" />
 		  </dependentAssembly>
 		  <dependentAssembly>
 			<assemblyIdentity name="NationalInstruments.VeriStand.SystemStorageUI" publicKeyToken="a6d690c380daa308" culture="Neutral" />
 			<!-- Assembly versions can be redirected in application, 
 			  publisher policy, or machine configuration files. -->
-			<bindingRedirect oldVersion="0.0.0.0-2015.1.0.0" newVersion="2016.0.0.0" />
+			<bindingRedirect oldVersion="0.0.0.0-65535.65535.65535.65535" newVersion="2016.0.0.0" />
 		  </dependentAssembly>
 		  <dependentAssembly>
 			<assemblyIdentity name="NationalInstruments.VeriStand.WorkspaceMacro" publicKeyToken="a6d690c380daa308" culture="Neutral" />
 			<!-- Assembly versions can be redirected in application, 
 			  publisher policy, or machine configuration files. -->
-			<bindingRedirect oldVersion="0.0.0.0-2015.1.0.0" newVersion="2016.0.0.0" />
+			<bindingRedirect oldVersion="0.0.0.0-65535.65535.65535.65535" newVersion="2016.0.0.0" />
 		  </dependentAssembly>
 		  <dependentAssembly>
 		  <assemblyIdentity name="NationalInstruments.VeriStand.XMLReader" publicKeyToken="a6d690c380daa308" culture="Neutral" />
 			<!-- Assembly versions can be redirected in application, 
 			  publisher policy, or machine configuration files. -->
-			<bindingRedirect oldVersion="0.0.0.0-2015.1.0.0" newVersion="2016.0.0.0" />
+			<bindingRedirect oldVersion="0.0.0.0-65535.65535.65535.65535" newVersion="2016.0.0.0" />
 		  </dependentAssembly>
 		  <dependentAssembly>
 		  <assemblyIdentity name="NationalInstruments.VeriStand.DataTypes" publicKeyToken="a6d690c380daa308" culture="Neutral" />
 			<!-- Assembly versions can be redirected in application, 
 			  publisher policy, or machine configuration files. -->
-			<bindingRedirect oldVersion="0.0.0.0-2015.1.0.0" newVersion="2016.0.0.0" />
+			<bindingRedirect oldVersion="0.0.0.0-65535.65535.65535.65535" newVersion="2016.0.0.0" />
 		  </dependentAssembly>
 		  <dependentAssembly>
 		  <assemblyIdentity name="NationalInstruments.VeriStand.ATMLTestResults" publicKeyToken="a6d690c380daa308" culture="Neutral" />
 			<!-- Assembly versions can be redirected in application, 
 			  publisher policy, or machine configuration files. -->
-			<bindingRedirect oldVersion="0.0.0.0-2015.1.0.0" newVersion="2016.0.0.0" />
+			<bindingRedirect oldVersion="0.0.0.0-65535.65535.65535.65535" newVersion="2016.0.0.0" />
 		  </dependentAssembly>
 		  <dependentAssembly>
 		  <assemblyIdentity name="NationalInstruments.VeriStand.RealTimeSequenceDefinitionApi" publicKeyToken="a6d690c380daa308" culture="Neutral" />
 			<!-- Assembly versions can be redirected in application, 
 			  publisher policy, or machine configuration files. -->
-			<bindingRedirect oldVersion="0.0.0.0-2015.1.0.0" newVersion="2016.0.0.0" />
+			<bindingRedirect oldVersion="0.0.0.0-65535.65535.65535.65535" newVersion="2016.0.0.0" />
 		  </dependentAssembly>
 		  <dependentAssembly>
 		  <assemblyIdentity name="NationalInstruments.VeriStand.UsiDotNetApi" publicKeyToken="a6d690c380daa308" culture="Neutral" />
 			<!-- Assembly versions can be redirected in application, 
 			  publisher policy, or machine configuration files. -->
-			<bindingRedirect oldVersion="0.0.0.0-2015.1.0.0" newVersion="2016.0.0.0" />
+			<bindingRedirect oldVersion="0.0.0.0-65535.65535.65535.65535" newVersion="2016.0.0.0" />
 		  </dependentAssembly>
 		  <dependentAssembly>
 		  <assemblyIdentity name="NationalInstruments.VeriStand.RealTimeSequenceDefinitionApiUtilities" publicKeyToken="a6d690c380daa308" culture="Neutral" />
 			<!-- Assembly versions can be redirected in application, 
 			  publisher policy, or machine configuration files. -->
-			<bindingRedirect oldVersion="0.0.0.0-2015.1.0.0" newVersion="2016.0.0.0" />
+			<bindingRedirect oldVersion="0.0.0.0-65535.65535.65535.65535" newVersion="2016.0.0.0" />
 		  </dependentAssembly>
 		  <dependentAssembly>
 		  <assemblyIdentity name="NationalInstruments.VeriStand.ASAM.XIL.Implementation.TestBench" publicKeyToken="a6d690c380daa308" culture="Neutral" />
 			<!-- Assembly versions can be redirected in application, 
 			  publisher policy, or machine configuration files. -->
-			<bindingRedirect oldVersion="0.0.0.0-2015.1.0.0" newVersion="2016.0.0.0" />
+			<bindingRedirect oldVersion="0.0.0.0-65535.65535.65535.65535" newVersion="2016.0.0.0" />
 		  </dependentAssembly>
 	<!-- ================================= Local files ==================================== -->
 		  <dependentAssembly>
 		  <assemblyIdentity name="NationalInstruments.VeriStand.CommonUI" publicKeyToken="a6d690c380daa308" culture="Neutral" />
 			<!-- Assembly versions can be redirected in application, 
 			  publisher policy, or machine configuration files. -->
-			<bindingRedirect oldVersion="0.0.0.0-2015.1.0.0" newVersion="2016.0.0.0" />
+			<bindingRedirect oldVersion="0.0.0.0-65535.65535.65535.65535" newVersion="2016.0.0.0" />
 		  </dependentAssembly>
 		  <dependentAssembly>
 		  <assemblyIdentity name="NationalInstruments.VeriStand.Compiler" publicKeyToken="a6d690c380daa308" culture="Neutral" />
 			<!-- Assembly versions can be redirected in application, 
 			  publisher policy, or machine configuration files. -->
-			<bindingRedirect oldVersion="0.0.0.0-2015.1.0.0" newVersion="2016.0.0.0" />
+			<bindingRedirect oldVersion="0.0.0.0-65535.65535.65535.65535" newVersion="2016.0.0.0" />
 		  </dependentAssembly>
 		  <dependentAssembly>
 		  <assemblyIdentity name="NationalInstruments.VeriStand.MacroPlayerRecorder" publicKeyToken="a6d690c380daa308" culture="Neutral" />
 			<!-- Assembly versions can be redirected in application, 
 			  publisher policy, or machine configuration files. -->
-			<bindingRedirect oldVersion="0.0.0.0-2015.1.0.0" newVersion="2016.0.0.0" />
+			<bindingRedirect oldVersion="0.0.0.0-65535.65535.65535.65535" newVersion="2016.0.0.0" />
 		  </dependentAssembly>
 		  <dependentAssembly>
 		  <assemblyIdentity name="NationalInstruments.VeriStand.ResXResourceManager" publicKeyToken="a6d690c380daa308" culture="Neutral" />
 			<!-- Assembly versions can be redirected in application, 
 			  publisher policy, or machine configuration files. -->
-			<bindingRedirect oldVersion="0.0.0.0-2015.1.0.0" newVersion="2016.0.0.0" />
+			<bindingRedirect oldVersion="0.0.0.0-65535.65535.65535.65535" newVersion="2016.0.0.0" />
 		  </dependentAssembly>
 		  <dependentAssembly>
 		  <assemblyIdentity name="NationalInstruments.VeriStand.ServerAPI" publicKeyToken="a6d690c380daa308" culture="Neutral" />
 			<!-- Assembly versions can be redirected in application, 
 			  publisher policy, or machine configuration files. -->
-			<bindingRedirect oldVersion="0.0.0.0-2015.1.0.0" newVersion="2016.0.0.0" />
+			<bindingRedirect oldVersion="0.0.0.0-65535.65535.65535.65535" newVersion="2016.0.0.0" />
 		  </dependentAssembly>
 		  <dependentAssembly>
 		  <assemblyIdentity name="NationalInstruments.VeriStand.UIStyleManager" publicKeyToken="a6d690c380daa308" culture="Neutral" />
 			<!-- Assembly versions can be redirected in application, 
 			  publisher policy, or machine configuration files. -->
-			<bindingRedirect oldVersion="0.0.0.0-2015.1.0.0" newVersion="2016.0.0.0" />
+			<bindingRedirect oldVersion="0.0.0.0-65535.65535.65535.65535" newVersion="2016.0.0.0" />
 		  </dependentAssembly>  
 		  <dependentAssembly>
 		  <assemblyIdentity name="NationalInstruments.VeriStand.DataTypes.Utilities.dll" publicKeyToken="a6d690c380daa308" culture="Neutral" />
 			<!-- Assembly versions can be redirected in application, 
 			  publisher policy, or machine configuration files. -->
-			<bindingRedirect oldVersion="0.0.0.0-2015.1.0.0" newVersion="2016.0.0.0" />
+			<bindingRedirect oldVersion="0.0.0.0-65535.65535.65535.65535" newVersion="2016.0.0.0" />
 		  </dependentAssembly>
 		</assemblyBinding>
 	</runtime>

--- a/resources/assemblyVersions.properties
+++ b/resources/assemblyVersions.properties
@@ -1,0 +1,2 @@
+#lvVersion map to VeriStand assembly versions
+2019 = 6.0.0.0

--- a/vars/copyProjectConfig.groovy
+++ b/vars/copyProjectConfig.groovy
@@ -10,6 +10,8 @@ def call(projectPath, lvVersion){
    def newAssemblyVersion = assemblyVersions."$lvVersion"
 
    def fileContent = readFile "niveristand-custom-device-build-tools/resources/LabVIEW.exe.config"
+
+   //https://regex101.com/r/tBNE56/2
    fileContent = fileContent.replaceAll("(newVersion=\")[^\"]+","\$1$newAssemblyVersion")
 
    writeFile file: configFileName, text: fileContent

--- a/vars/copyProjectConfig.groovy
+++ b/vars/copyProjectConfig.groovy
@@ -3,16 +3,11 @@
 def call(projectPath, lvVersion){
    echo "Copying configuration file for $projectPath"
    configFileName = "$projectPath" + ".config"
-   
-   def currentVersion = lvVersion as int
-   def newAssemblyVersion = "${currentVersion}.0.0.0"
-   
-   def previousVersion = currentVersion - 1
-   def oldAssemblyVersion = "0.0.0.0-${previousVersion}.9.9.9"
-   
+
+   def newAssemblyVersion = "${lvVersion}.0.0.0"
+
    def fileContent = readFile "niveristand-custom-device-build-tools/resources/LabVIEW.exe.config"
-   fileContent = fileContent.replaceAll("(oldVersion=\")[^\"]+","\$1$oldAssemblyVersion")
-      .replaceAll("(newVersion=\")[^\"]+","\$1$newAssemblyVersion")
-   
+   fileContent = fileContent.replaceAll("(newVersion=\")[^\"]+","\$1$newAssemblyVersion")
+
    writeFile file: configFileName, text: fileContent
 }

--- a/vars/copyProjectConfig.groovy
+++ b/vars/copyProjectConfig.groovy
@@ -4,7 +4,7 @@ def call(projectPath, lvVersion){
    echo "Copying configuration file for $projectPath"
    configFileName = "$projectPath" + ".config"
    
-   def defaultVersion = ["$lvVersion": "{$lvVersion}.0.0.0"]
+   def defaultVersion = ["$lvVersion": "${lvVersion}.0.0.0"]
    def assemblyVersions = readProperties defaults: defaultVersion, file: "niveristand-custom-device-build-tools/resources/assemblyVersions.properties"
 
    def newAssemblyVersion = assemblyVersions."$lvVersion"

--- a/vars/copyProjectConfig.groovy
+++ b/vars/copyProjectConfig.groovy
@@ -3,8 +3,11 @@
 def call(projectPath, lvVersion){
    echo "Copying configuration file for $projectPath"
    configFileName = "$projectPath" + ".config"
+   
+   def defaultVersion = ["$lvVersion": "{$lvVersion}.0.0.0"]
+   def assemblyVersions = readProperties defaults: defaultVersion, file: "niveristand-custom-device-build-tools/resources/assemblyVersions.properties"
 
-   def newAssemblyVersion = "${lvVersion}.0.0.0"
+   def newAssemblyVersion = assemblyVersions."$lvVersion"
 
    def fileContent = readFile "niveristand-custom-device-build-tools/resources/LabVIEW.exe.config"
    fileContent = fileContent.replaceAll("(newVersion=\")[^\"]+","\$1$newAssemblyVersion")


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-custom-device-build-tools/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Enables the build system to use a version of the VeriStand assemblies other than \<year\>.0.0.0.
Also simplifies redirection so we don't have to modify both the old version and new version in the `.config` file. Only the current version is now required.

### Why should this Pull Request be merged?

VeriStand 2019 uses a different versioning scheme, so the current method of redirecting assemblies is insufficient for building new custom devices.

### What testing has been done?

Built Synchronization custom device 2016-2019.
[Results](http://coordinator/job/VeriStand/job/buckd/job/niveristand-synchronization-custom-device/job/master/3/)
