### PR TITLE
Enable multibranch pipeline without GitHub

### DIFF
--- a/src/ni/vsbuild/stages/Archive.groovy
+++ b/src/ni/vsbuild/stages/Archive.groovy
@@ -27,9 +27,20 @@ class Archive extends AbstractStage {
 
    // Builds a string of the form <archiveLocation>\\export\\<branch>\\<build_number>
    private void setArchiveLocation() {
-      archiveLocation = configuration.archive.get('archive_location') +
-         "\\${script.getComponentParts()['organization']}" +
-         "\\export\\${script.env.BRANCH_NAME}\\" +
+      def organization = script.getComponentParts()['organization']
+
+      // Organization may not exist for multibranch pipelines not using
+      // the GitHub Branch Source Plugin
+      if(!organization) {
+         organization = ''
+      }
+      else {
+         organization = "$organization\\"
+      }
+
+      archiveLocation = "${configuration.archive.get('archive_location')}\\" +
+         "$organization" +
+         "export\\${script.env.BRANCH_NAME}\\" +
          "Build ${script.currentBuild.number}"
    }
 

--- a/vars/getComponentParts.groovy
+++ b/vars/getComponentParts.groovy
@@ -7,7 +7,9 @@ def call() {
    def parts = ['branch', 'repo', 'organization']
 
    for(i = 0; i < tokenCount; i++) {
-      partMap[parts[i]] = tokens[index]
+      if(parts[i]) {
+         partMap[parts[i]] = tokens[index]
+      }
       index--
    }
 

--- a/vars/getComponentParts.groovy
+++ b/vars/getComponentParts.groovy
@@ -1,8 +1,15 @@
 def call() {
    def partMap = [:]
    def tokens = env.JOB_NAME.tokenize("/")
-   partMap['branch'] = tokens[-1]
-   partMap['repo'] = tokens[-2]
-   partMap['organization'] = tokens[-3]
+   def tokenCount = tokens.size()
+
+   def index = -1
+   def parts = ['branch', 'repo', 'organization']
+
+   for(i = 0; i < tokenCount; i++) {
+      partMap[parts[i]] = tokens[index]
+      index--
+   }
+
    return partMap
 }


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-custom-device-build-tools/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Decouples the job name component parts from the GitHub Branch Source Plugin.
- If only a repo and branch name exist, allow getComponentParts() to still return these values.
- Only archive to organization directory if the organization is defined.

### Why should this Pull Request be merged?

Fixes #48 

### What testing has been done?

- Built [testbuild component](http://coordinator/blue/organizations/jenkins/VeriStand%2Fbuckd%2Ftestbuild/detail/master/46/pipeline) using changes to verify the GitHub Branch Source Plugin job names still work correctly.
- Tested logic at https://groovy-playground.appspot.com/ to make sure the paths are correctly calculated using the new algorithm.
