### PR TITLE
Enable building empty (virtual) packages

### DIFF
--- a/src/ni/vsbuild/packages/Nipkg.groovy
+++ b/src/ni/vsbuild/packages/Nipkg.groovy
@@ -93,7 +93,19 @@ class Nipkg extends AbstractPackage {
    }
 
    private void stagePayload() {
+      def stageDirectory = "$PACKAGE_DIRECTORY\\$DATA_DIRECTORY"
+
+      if(!installDestination) {
+         // Create the stage directory to enable building
+         // empty packages.
+         // An empty package (virtual package) is useful for
+         // defining package relationships without requiring a
+         // package payload.
+         script.bat "mkdir \"$stageDirectory\""
+         return
+      }
+
       def destination = updateVersionVariables(installDestination)
-      script.copyFiles(payloadDir, "$PACKAGE_DIRECTORY\\$DATA_DIRECTORY\\$destination")
+      script.copyFiles(payloadDir, "$stageDirectory\\$destination")
    }
 }

--- a/src/ni/vsbuild/packages/Nipkg.groovy
+++ b/src/ni/vsbuild/packages/Nipkg.groovy
@@ -93,19 +93,15 @@ class Nipkg extends AbstractPackage {
    }
 
    private void stagePayload() {
-      def stageDirectory = "$PACKAGE_DIRECTORY\\$DATA_DIRECTORY"
-
       if(!installDestination) {
-         // Create the stage directory to enable building
-         // empty packages.
-         // An empty package (virtual package) is useful for
-         // defining package relationships without requiring a
-         // package payload.
-         script.bat "mkdir \"$stageDirectory\""
+         // If installDestination is not provided, build an
+         // empty package (virtual package).
+         // A virtual package is useful for defining package
+         // relationships without requiring a package payload.
          return
       }
 
       def destination = updateVersionVariables(installDestination)
-      script.copyFiles(payloadDir, "$stageDirectory\\$destination")
+      script.copyFiles(payloadDir, "$PACKAGE_DIRECTORY\\$DATA_DIRECTORY\\$destination")
    }
 }


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-custom-device-build-tools/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Allows the user to specify an empty install path for nipkgs.

### Why should this Pull Request be merged?

Virtual packages contain no payload, they just set recommends/suggests/other relationships between packages. NIPM store items are generally virtual packages and the custom device feed will use a virtual package as the top-level package.

### What testing has been done?

[Built nipkg](http://coordinator/blue/organizations/jenkins/VeriStand%2Fbuckd%2Fniveristand-custom-device-virtual-package/detail/release%2F19.0/3/pipeline/5) with an empty path.
