### PR TITLE
Remove manifest from nipkg installer

### DIFF
--- a/src/ni/vsbuild/packages/Nipkg.groovy
+++ b/src/ni/vsbuild/packages/Nipkg.groovy
@@ -28,7 +28,7 @@ class Nipkg extends AbstractPackage {
       stageFiles()
 
       def nipkgOutput = script.nipkgBuild(PACKAGE_DIRECTORY, PACKAGE_DIRECTORY)
-      script.copyFiles(PACKAGE_DIRECTORY, "\"$payloadDir\\$INSTALLER_DIRECTORY\"", nipkgOutput)
+      script.copyFiles(PACKAGE_DIRECTORY, "\"$payloadDir\\$INSTALLER_DIRECTORY\"", [files: nipkgOutput])
    }
 
    // This method is responsible for setting up the directory and file
@@ -102,9 +102,6 @@ class Nipkg extends AbstractPackage {
       }
 
       def destination = updateVersionVariables(installDestination)
-      script.copyFiles(payloadDir, "$PACKAGE_DIRECTORY\\$DATA_DIRECTORY\\$destination")
-
-      // Don't include manifest in package
-      script.bat "del /f /s /q \"$PACKAGE_DIRECTORY\\$DATA_DIRECTORY\\$destination\\manifest.*\""
+      script.copyFiles(payloadDir, "$PACKAGE_DIRECTORY\\$DATA_DIRECTORY\\$destination", [exclusions: "*manifest.*"])
    }
 }

--- a/src/ni/vsbuild/packages/Nipkg.groovy
+++ b/src/ni/vsbuild/packages/Nipkg.groovy
@@ -103,5 +103,8 @@ class Nipkg extends AbstractPackage {
 
       def destination = updateVersionVariables(installDestination)
       script.copyFiles(payloadDir, "$PACKAGE_DIRECTORY\\$DATA_DIRECTORY\\$destination")
+
+      // Don't include manifest in package
+      script.bat "del /f /s /q \"$PACKAGE_DIRECTORY\\$DATA_DIRECTORY\\$destination\\manifest.*\""
    }
 }

--- a/vars/copyFiles.groovy
+++ b/vars/copyFiles.groovy
@@ -1,17 +1,21 @@
-def call(sourceDirectory, destinationDirectory, files=null) {
+def call(sourceDirectory, destinationDirectory, options=[:]) {
    def copyCommand = "robocopy \"$sourceDirectory\" \"$destinationDirectory\""
 
    // These switches are for console output suppression so we don't get a bunch of junk
    // in our logs
    // https://ss64.com/nt/robocopy.html
-   def commandSwitches = "/NFL /NDL /NJH /NJS /nc /ns /np"
+   def commandSwitches = "/nfl /ndl /njh /njs /nc /ns /np"
+
+   if(options.exclusions) {
+      commandSwitches = "$commandSwitches /xf \"${options.exclusions}\""
+   }
 
    // If the files argument is not passed, mirror the entire source to destination
-   if(!files || files == null) {
-      commandSwitches = "$commandSwitches /MIR"
+   if(options.files) {
+      copyCommand = "$copyCommand \"${options.files}\""
    }
    else {
-      copyCommand = "$copyCommand \"$files\""
+      commandSwitches = "$commandSwitches /mir"
    }
 
    // robocopy uses multiple return codes for success


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-custom-device-build-tools/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Does not install the `manifest.json` file when the custom device is installed. While it would be nice to install the manifest with the custom device, currently, what you get is a single `installer` directory and only the manifest of the last custom device that was installed. This makes it useless and wasteful.

### Why should this Pull Request be merged?

Fixes #40 

### What testing has been done?

Built a [test release](http://coordinator/job/VeriStand/job/buckd/job/testbuild/job/release-18.1/134/) and the manifest is not included in the installer.
