### PR TITLE
Use change branch for dependencies in PR builds

### DIFF
--- a/vars/buildDependencies.groovy
+++ b/vars/buildDependencies.groovy
@@ -41,13 +41,14 @@ def call(buildInformation) {
             }
          }
 
-         escapedBranchName = "${env.BRANCH_NAME}".replace("/", "%2F")
+         def branchName = env.CHANGE_BRANCH ?: env.BRANCH_NAME
+         escapedBranchName = "$branchName".replace("/", "%2F")
          dependencyBuild = build "../$dependency/${escapedBranchName}"
       } catch(AbortException e) {
          // check if there is a job for the current branch name
          if(e.getMessage().startsWith('No item named')) {
             echo e.getMessage()
-            echo "Building branch master instead of ${env.BRANCH_NAME}."
+            echo "Building branch master instead of $branchName."
             dependencyBuild = build "../$dependency/master"
          } else {
             // job was found, but an exception occurred during build


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-custom-device-build-tools/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Tries to match branch names for dependency builds based on the branch initializing a pull request. If this is not a PR build, the env variable won't exist, so fall back to the original implementation.

### Why should this Pull Request be merged?

Fixes #56 

### What testing has been done?

Built a PR with dependencies. Branch selection shown below. The item was not found because there is already a PR for the corresponding branch, but the logic to choose the branch name is correct.
![image](https://user-images.githubusercontent.com/29306186/59371058-96754280-8d09-11e9-9f57-1cb87f725330.png)

