### PR TITLE
Evaluate version tags during build initialization

### DIFF
--- a/src/ni/vsbuild/BuildConfiguration.groovy
+++ b/src/ni/vsbuild/BuildConfiguration.groovy
@@ -81,7 +81,8 @@ class BuildConfiguration implements Serializable {
    }
 
    private static def replaceTags(def script, def jsonItem, def lvVersion) {
-      if(jsonItem instanceof java.lang.String || jsonItem instanceof org.codehaus.groovy.runtime.GStringImpl) {
+      if(jsonItem instanceof java.lang.String ||
+         jsonItem instanceof org.codehaus.groovy.runtime.GStringImpl) {
 
          def replacedValue = jsonItem
          script.versionReplacementExpressions().each {expression ->
@@ -102,4 +103,5 @@ class BuildConfiguration implements Serializable {
             jsonItem[key] = replaceTags(script, jsonItem[key], lvVersion)
          }
       }
+   }
 }

--- a/src/ni/vsbuild/BuildConfiguration.groovy
+++ b/src/ni/vsbuild/BuildConfiguration.groovy
@@ -103,5 +103,7 @@ class BuildConfiguration implements Serializable {
             jsonItem[key] = replaceTags(script, jsonItem[key], lvVersion)
          }
       }
+
+      return jsonItem
    }
 }

--- a/src/ni/vsbuild/BuildConfiguration.groovy
+++ b/src/ni/vsbuild/BuildConfiguration.groovy
@@ -82,7 +82,7 @@ class BuildConfiguration implements Serializable {
 
    private static def replaceTags(def script, def jsonItem, def lvVersion) {
       if(jsonItem instanceof java.lang.String ||
-         jsonItem instanceof org.codehaus.groovy.runtime.GStringImpl) {
+         jsonItem instanceof groovy.lang.GString) {
 
          def replacedValue = jsonItem
          script.versionReplacementExpressions().each {expression ->
@@ -93,7 +93,7 @@ class BuildConfiguration implements Serializable {
       }
 
       if(jsonItem instanceof java.util.ArrayList) {
-         for(def i=0; i< jsonItem.size(); i++) {
+         for(def i = 0; i < jsonItem.size(); i++) {
             jsonItem[i] = replaceTags(script, jsonItem[i], lvVersion)
          }
       }

--- a/src/ni/vsbuild/BuildConfiguration.groovy
+++ b/src/ni/vsbuild/BuildConfiguration.groovy
@@ -28,13 +28,15 @@ class BuildConfiguration implements Serializable {
       this.packageInfo = packageInfo
    }
 
-   static BuildConfiguration load(def script, String jsonFile) {
+   static BuildConfiguration load(def script, String jsonFile, String lvVersion) {
       def config = script.readJSON file: jsonFile
 
       // Convert the JSON to HashMaps instead of using the JsonObject
       // because the Pipeline security plugin disables lots of JsonObject
       // functionality that is required for this build system
       def convertedJson = new JsonSlurperClassic().parseText(config.toString())
+
+      convertedJson = replaceTags(script, convertedJson, lvVersion)
 
       return new BuildConfiguration(
          convertedJson.archive,
@@ -76,5 +78,32 @@ class BuildConfiguration implements Serializable {
       }
 
       return list
+   }
+
+   private static def replaceTags(def script, def jsonItem, def lvVersion) {
+      if(jsonItem instanceof java.lang.String ||
+         jsonItem instanceof org.codehaus.groovy.runtime.GStringImpl) {
+
+         def replacedValue = jsonItem
+         script.versionReplacementExpressions().each {expression ->
+            replacedValue = replacedValue.replaceAll("\\{$expression\\}", lvVersion)
+         }
+
+         return replacedValue
+      }
+
+      if(jsonItem instanceof java.util.ArrayList) {
+         for(def i=0; i< jsonItem.size(); i++) {
+            jsonItem[i] = replaceTags(script, jsonItem[i], lvVersion)
+         }
+      }
+
+      if(jsonItem instanceof java.util.HashMap) {
+         for(def key : jsonItem.keySet()) {
+            jsonItem[key] = replaceTags(script, jsonItem[key], lvVersion)
+         }
+      }
+
+      return jsonItem
    }
 }

--- a/src/ni/vsbuild/BuildConfiguration.groovy
+++ b/src/ni/vsbuild/BuildConfiguration.groovy
@@ -81,8 +81,7 @@ class BuildConfiguration implements Serializable {
    }
 
    private static def replaceTags(def script, def jsonItem, def lvVersion) {
-      if(jsonItem instanceof java.lang.String ||
-         jsonItem instanceof org.codehaus.groovy.runtime.GStringImpl) {
+      if(jsonItem instanceof java.lang.String || jsonItem instanceof org.codehaus.groovy.runtime.GStringImpl) {
 
          def replacedValue = jsonItem
          script.versionReplacementExpressions().each {expression ->

--- a/src/ni/vsbuild/Pipeline.groovy
+++ b/src/ni/vsbuild/Pipeline.groovy
@@ -107,7 +107,7 @@ class Pipeline implements Serializable {
             script.node(nodeLabel) {
                setup(lvVersion)
 
-               def configuration = BuildConfiguration.load(script, JSON_FILE)
+               def configuration = BuildConfiguration.load(script, JSON_FILE, lvVersion)
                configuration.printInformation(script)
 
                def builder = new Builder(script, configuration, lvVersion)

--- a/src/ni/vsbuild/packages/Nipkg.groovy
+++ b/src/ni/vsbuild/packages/Nipkg.groovy
@@ -80,9 +80,6 @@ class Nipkg extends AbstractPackage {
       def fullVersion = getFullVersion()
 
       def replacements = ['nipkg_version': fullVersion, 'display_version': baseVersion]
-      script.versionReplacementExpressions().each { expression ->
-         replacements."$expression" = lvVersion
-      }
 
       def updatedText = text
       replacements.each {expression, value ->

--- a/src/ni/vsbuild/packages/Nipkg.groovy
+++ b/src/ni/vsbuild/packages/Nipkg.groovy
@@ -80,6 +80,9 @@ class Nipkg extends AbstractPackage {
       def fullVersion = getFullVersion()
 
       def replacements = ['nipkg_version': fullVersion, 'display_version': baseVersion]
+      script.versionReplacementExpressions().each { expression ->
+         replacements."$expression" = lvVersion
+      }
 
       def updatedText = text
       replacements.each {expression, value ->


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-custom-device-build-tools/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Enables a user to put the _{veristand_version}_ or _{labview_version}_ tags anywhere in `build.toml` and have them evaluated without having to write extra code into each stage.

### Why should this Pull Request be merged?

Fixes #68 

### What testing has been done?

Test build: http://coordinator/job/VeriStand/job/buckd/job/testbuild/job/release%252F19.0/3/
