### PR TITLE
Update LabVIEW version in README to 2015

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ project = '{cd}'
 Stages are ordered by the pipeline. Steps within the codegen and build stages are executed in the top to bottom order specified in `build.toml`. For a complete description of the available TOML configuration options, see the [build.toml specification](docs/Toml%20Help.md).
 
 ## LabVIEW Version
-The LabVIEW source for this repository is saved for LabVIEW 2014, but is forward compatible to newer versions.
+The LabVIEW source for this repository is saved for LabVIEW 2015, but is forward compatible to newer versions.
 
 ## Dependencies
 The following top-level dependencies are required on the build machine to use the repository:


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-custom-device-build-tools/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Fix the incorrect LabVIEW version in the README.

We are not mass compiling the repository to 2016 right now, so 2015 is correct.

### Why should this Pull Request be merged?

The existing information is incorrect.

### What testing has been done?

None.