### PR TITLE
Archive manifest if not automatically included

### DIFF
--- a/src/ni/vsbuild/Pipeline.groovy
+++ b/src/ni/vsbuild/Pipeline.groovy
@@ -17,12 +17,14 @@ class Pipeline implements Serializable {
       def script
       BuildConfiguration buildConfiguration
       String lvVersion
+      String manifestFile
       def stages = []
 
-      Builder(def script, BuildConfiguration buildConfiguration, String lvVersion) {
+      Builder(def script, BuildConfiguration buildConfiguration, String lvVersion, String manifestFile) {
          this.script = script
          this.buildConfiguration = buildConfiguration
          this.lvVersion = lvVersion
+         this.manifestFile = manifestFile
       }
 
       def withCodegenStage() {
@@ -42,7 +44,7 @@ class Pipeline implements Serializable {
       }
 
       def withArchiveStage() {
-         stages << new Archive(script, buildConfiguration, lvVersion)
+         stages << new Archive(script, buildConfiguration, lvVersion, manifestFile)
       }
 
       // The plan is to enable automatic merging from master to
@@ -110,7 +112,7 @@ class Pipeline implements Serializable {
                def configuration = BuildConfiguration.load(script, JSON_FILE, lvVersion)
                configuration.printInformation(script)
 
-               def builder = new Builder(script, configuration, lvVersion)
+               def builder = new Builder(script, configuration, lvVersion, MANIFEST_FILE)
                this.stages = builder.buildPipeline()
 
                executeStages()

--- a/src/ni/vsbuild/stages/Archive.groovy
+++ b/src/ni/vsbuild/stages/Archive.groovy
@@ -4,10 +4,15 @@ import ni.vsbuild.BuildConfiguration
 
 class Archive extends AbstractStage {
 
-   private String archiveLocation
+   private static final String MANIFEST_ARCHIVE_DIR = 'installer'
 
-   Archive(script, configuration, lvVersion) {
+   private String archiveLocation
+   private String manifestFile
+
+   Archive(script, configuration, lvVersion, manifestFile) {
       super(script, 'Archive', configuration, lvVersion)
+
+      this.manifestFile = manifestFile
    }
 
    void executeStage() {
@@ -20,7 +25,10 @@ class Archive extends AbstractStage {
          buildOutputDir = BuildConfiguration.STAGING_DIR
       }
 
-      script.copyFiles(buildOutputDir, "$archiveLocation\\$lvVersion")
+      def versionedArchive = "$archiveLocation\\$lvVersion"
+      script.copyFiles(buildOutputDir, versionedArchive)
+
+      archiveManifest(versionedArchive)
 
       setArchiveVar()
    }
@@ -49,5 +57,17 @@ class Archive extends AbstractStage {
       def component = script.getComponentParts()['repo']
       def depDir = "${component}_DEP_DIR"
       script.env."$depDir" = archiveLocation
+   }
+   
+   private void archiveManifest(String versionedArchive) {
+      def splitIndex = manifestFile.lastIndexOf('/')
+      def manifestFileName = manifestFile.substring(splitIndex + 1)
+      
+      def versionedInstallerDir = "$versionedArchive\\$MANIFEST_ARCHIVE_DIR"
+
+      if(!script.fileExists("$versionedInstallerDir\\$manifestFileName")) {
+         def manifestDirectory = manifestFile.take(splitIndex)
+         script.copyFiles(manifestDirectory, versionedInstallerDir, [files: manifestFileName])
+      }
    }
 }


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-custom-device-build-tools/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Checks if the `manifest.json` file exists after archiving. If not, the file is archived.

### Why should this Pull Request be merged?

Due to a bug in Application Builder, the Routing and Faulting custom device has to create builds at `Source/Built` instead of our typical `Built` location. The `manifest.json` goes to `Built`, which is not archived for the Routing and Faulting custom device, so we have to add an additional step to archive it.

Without this, the automated tests won't run.
Fixes [niveristand-routing-and-faulting-custom-devcice-#4](https://github.com/ni/niveristand-routing-and-faulting-custom-device/issues/4)

### What testing has been done?

[Built](http://coordinator/job/VeriStand/job/ni/job/niveristand-routing-and-faulting-custom-device/job/dev%2Fmanifest-test/10/) and ensured `manifest.json` is correctly archived.
![image](https://user-images.githubusercontent.com/29306186/64634096-1fac1c00-d3c2-11e9-816e-8d11a1d2cc8f.png)

