### PR TITLE
Support building .nipkg packages that install files to multiple roots

### DIFF
--- a/src/ni/vsbuild/packages/AbstractPackage.groovy
+++ b/src/ni/vsbuild/packages/AbstractPackage.groovy
@@ -6,7 +6,6 @@ abstract class AbstractPackage implements Buildable {
 
    def script
    def type
-   def payloadDir
    def lvVersion
    def packageOutputDir
 
@@ -14,7 +13,6 @@ abstract class AbstractPackage implements Buildable {
       this.script = script
       this.lvVersion = lvVersion
       this.type = packageInfo.get('type')
-      this.payloadDir = packageInfo.get('payload_dir')
       this.packageOutputDir = packageInfo.get('package_output_dir') ?: packageInfo.get('payload_dir')
    }
 

--- a/src/ni/vsbuild/packages/Nipkg.groovy
+++ b/src/ni/vsbuild/packages/Nipkg.groovy
@@ -11,12 +11,14 @@ class Nipkg extends AbstractPackage {
    private static final String CONTROL_DIRECTORY = "control"
    private static final String DATA_DIRECTORY = "data"
 
+   def payloadDir
    def installDestination
    def controlFile
    def instructionsFile
 
    Nipkg(script, packageInfo, lvVersion) {
       super(script, packageInfo, lvVersion)
+      this.payloadDir = packageInfo.get('payload_dir')
 
       // Yes, I'm calling toString() on what appears to be a string, but is not actually
       // java.lang.String. Instead, the interpolated string is a groovy.lang.GString.

--- a/src/ni/vsbuild/packages/Nipkg.groovy
+++ b/src/ni/vsbuild/packages/Nipkg.groovy
@@ -107,6 +107,7 @@ class Nipkg extends AbstractPackage {
    }
 
    private void stagePayload() {
+      this.script.echo this.payloadMap
       if (this.payloadMap.size() == 1) {
          def value = this.payloadMap.values().first()
          if (!value) {

--- a/src/ni/vsbuild/packages/Nipkg.groovy
+++ b/src/ni/vsbuild/packages/Nipkg.groovy
@@ -17,7 +17,7 @@ class Nipkg extends AbstractPackage {
 
    Nipkg(script, packageInfo, lvVersion) {
       super(script, packageInfo, lvVersion)
-      createPayloadMap(packageInfo)
+      this.createPayloadMap(packageInfo)
       this.controlFile = packageInfo.get('control_file') ?: CONTROL_FILE_NAME
       this.instructionsFile = packageInfo.get('instructions_file') ?: INSTRUCTIONS_FILE_NAME
    }

--- a/src/ni/vsbuild/packages/Nipkg.groovy
+++ b/src/ni/vsbuild/packages/Nipkg.groovy
@@ -29,6 +29,7 @@ class Nipkg extends AbstractPackage {
       script.copyFiles(PACKAGE_DIRECTORY, "\"$outputLocation\"", [files: nipkgOutput])
    }
 
+   @NonCPS
    private void createPayloadMap(packageInfo) {
       def payloadDir = packageInfo.get('payload_dir')
       // Yes, I'm calling toString() on what appears to be a string, but is not actually

--- a/src/ni/vsbuild/packages/Nipkg.groovy
+++ b/src/ni/vsbuild/packages/Nipkg.groovy
@@ -43,7 +43,7 @@ class Nipkg extends AbstractPackage {
       if (payloadDir) {
          this.payloadMap = [(payloadDir): installDestination]
       } else {
-         this.payloadMap = packageInfo.get('payload_map')[0]
+         this.payloadMap = packageInfo.get('payload_map')
       }
 
       if (!this.payloadMap) {

--- a/src/ni/vsbuild/packages/Nipkg.groovy
+++ b/src/ni/vsbuild/packages/Nipkg.groovy
@@ -108,7 +108,7 @@ class Nipkg extends AbstractPackage {
 
    private void stagePayload() {
       if (this.payloadMap.size() == 1) {
-         def value = this.payloadMap.toArray()[0]
+         def value = this.payloadMap.values().first()
          if (!value) {
             // If installDestination is not provided, build an
             // empty package (virtual package).

--- a/src/ni/vsbuild/packages/Nipkg.groovy
+++ b/src/ni/vsbuild/packages/Nipkg.groovy
@@ -107,7 +107,7 @@ class Nipkg extends AbstractPackage {
    }
 
    private void stagePayload() {
-      this.script.echo this.payloadMap
+      this.script.echo this.payloadMap.toString()
       if (this.payloadMap.size() == 1) {
          def value = this.payloadMap.values().first()
          if (!value) {

--- a/src/ni/vsbuild/packages/Nipkg.groovy
+++ b/src/ni/vsbuild/packages/Nipkg.groovy
@@ -41,7 +41,7 @@ class Nipkg extends AbstractPackage {
       def installDestination = packageInfo.get("${lvVersion}_install_destination".toString()) ?: packageInfo.get('install_destination')
 
       if (payloadDir) {
-         this.payloadMap = [payloadDir: installDestination]
+         this.payloadMap = [(payloadDir): installDestination]
       } else {
          this.payloadMap = packageInfo.get('payload_map')
       }

--- a/src/ni/vsbuild/packages/Nipkg.groovy
+++ b/src/ni/vsbuild/packages/Nipkg.groovy
@@ -107,7 +107,6 @@ class Nipkg extends AbstractPackage {
    }
 
    private void stagePayload() {
-      this.script.echo this.payloadMap.toString()
       if (this.payloadMap.size() == 1) {
          def value = this.payloadMap.values().first()
          if (!value) {

--- a/src/ni/vsbuild/packages/Nipkg.groovy
+++ b/src/ni/vsbuild/packages/Nipkg.groovy
@@ -43,7 +43,7 @@ class Nipkg extends AbstractPackage {
       if (payloadDir) {
          this.payloadMap = [(payloadDir): installDestination]
       } else {
-         this.payloadMap = packageInfo.get('payload_map')
+         this.payloadMap = packageInfo.get('payload_map')[0]
       }
 
       if (!this.payloadMap) {

--- a/src/ni/vsbuild/packages/Zip.groovy
+++ b/src/ni/vsbuild/packages/Zip.groovy
@@ -2,8 +2,11 @@ package ni.vsbuild.packages
 
 class Zip extends AbstractPackage {
 
+   def payloadDir
+
    Zip(script, packageInfo, lvVersion) {
       super(script, packageInfo, lvVersion)
+      this.payloadDir = packageInfo.get('payload_dir')
    }
 
    void buildPackage(outputLocation) {


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-custom-device-build-tools/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Add support for building packages that install to multiple roots.

### Why should this Pull Request be merged?

This is needed to support installing `.bin4` files for example finder integration as part of LabVIEW support packages.

### What testing has been done?

- [Multi root build](http://coordinator/job/VeriStand/job/rtzoeller/job/testbuild/job/release%252F19.0/12/console)
- [Virtual package build](http://coordinator/job/VeriStand/job/rtzoeller/job/niveristand-custom-device-virtual-package/job/release%252F19.2/1/console)