### PR TITLE
[merge_release_branch.py] Print repository name in a banner before merging each repo

### DIFF
--- a/resources/merge_release_branch.py
+++ b/resources/merge_release_branch.py
@@ -51,5 +51,10 @@ if __name__ == "__main__":
     import sys
 
     file_contents = toml.load(sys.argv[1])
-    for project in file_contents.values():
+    for name, project in file_contents.items():
+        print()
+        print("*" * 80)
+        print("Merging release branch '{0}' for {1}".format(project["version"], name))
+        print("*" * 80)
         integrate_release(project["url"], project["version"], project["directory"])
+        print()


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-custom-device-build-tools/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Sample output:

```
********************************************************************************
Merging release branch '19.2' for Routing and Faulting
********************************************************************************
On branch release/19.2
Your branch is up to date with 'origin/release/19.2'.

nothing to commit, working tree clean
Switched to branch 'master'
Your branch is up to date with 'origin/master'.
Already up to date.
Switched to and reset branch 'release/19.2'
Your branch is up to date with 'origin/release/19.2'.
Everything up-to-date
Branch 'release/19.2' set up to track remote branch 'release/19.2' from 'origin'.


********************************************************************************
Merging release branch '19.2' for Message Library
********************************************************************************
On branch release/19.2
Your branch is up to date with 'origin/release/19.2'.

nothing to commit, working tree clean
Switched to branch 'master'
Your branch is up to date with 'origin/master'.
Already up to date.
Switched to and reset branch 'release/19.2'
Your branch is up to date with 'origin/release/19.2'.
Everything up-to-date
Branch 'release/19.2' set up to track remote branch 'release/19.2' from 'origin'.


********************************************************************************
Merging release branch '19.2' for SLSC Message Library
********************************************************************************
On branch release/19.2
Your branch is up to date with 'origin/release/19.2'.

nothing to commit, working tree clean
Switched to branch 'master'
Your branch is up to date with 'origin/master'.
Already up to date.
Switched to and reset branch 'release/19.2'
Your branch is up to date with 'origin/release/19.2'.
Everything up-to-date
Branch 'release/19.2' set up to track remote branch 'release/19.2' from 'origin'.
```

### Why should this Pull Request be merged?

Closes #73 

### What testing has been done?

Ran the release branch merger and confirmed it prints information as expected.