### PR TITLE
Add legacy product upgrade codes as substitution variables

### DIFF
--- a/src/ni/vsbuild/StringSubstitution.groovy
+++ b/src/ni/vsbuild/StringSubstitution.groovy
@@ -44,14 +44,15 @@ class StringSubstitution implements Serializable {
       // Update the upper bound with each additional year release that uses the same package name format
       // Once we no longer need the legacy codes (i.e. the minimum supported VeriStand version is 2019) we
       // can deprecate this function, and just use the package names and versions directly.
-      for (int year = 19; year <= 20; year++)
+      def upperYearBound = 20
+      for (int year = 19; year <= upperYearBound; year++)
       {
          substitutionStrings.put(
                "ni-veristand-20${year}".toString(),
                "ni-veristand-20${year}".toString(),
          )
       }
-      for (int year = 18; year <= 20; year++)
+      for (int year = 18; year <= upperYearBound; year++)
       {
          substitutionStrings.put(
                "AUTOVERSION_ni-labview-20${year}-x86".toString(),

--- a/src/ni/vsbuild/StringSubstitution.groovy
+++ b/src/ni/vsbuild/StringSubstitution.groovy
@@ -11,7 +11,9 @@ class StringSubstitution implements Serializable {
       replacements << getLegacySubstitutionStrings()
       replacements << additionalReplacements
 
-      // Potentially run multiple times to allow nested replacement strings, e.g. "{ni-veristand-{veristand_version}}"
+      // Potentially run multiple times to allow nested replacement strings,
+      // e.g. "{ni-veristand-{veristand_version}} (>=labview_short_version.0.0)"
+      // or "{AUTOVERSION_ni-labview-{labview_version}-x86}"
       def updatedText = text
       def modified = true
       while (modified)
@@ -29,25 +31,32 @@ class StringSubstitution implements Serializable {
    private static Map<String, String> getLegacySubstitutionStrings()
    {
       def substitutionStrings = [
-            "ni-veristand-2016": "b8da4f0a-93cc-45f2-8fe8-5cf878017dc1",
             "ni-veristand-2017": "89bad39c-da8d-4c78-ba1a-f5de0dafdc00",
             "ni-veristand-2018": "d8f1d4e0-3466-42b0-92da-bdad96c42600",
-            "ni-labview-2016-x86": "7e1db25d-3f73-4659-a889-2b88330ebec6",
-            "ni-labview-2017-x86": "b0f7b394-1d4e-4350-9852-b5bdb2d64cb2",
+            // We cannot simply map to the upgrade code defined by LabVIEW 2017, because
+            // LabVIEW 2017 SP1 defines a different one. Instead we need to OR them, so that the
+            // presence of either is sufficient. This makes listing the dependency in a control file
+            // slightly awkward since you won't list a version; we prefix the variable with AUTOVERSION_
+            // to hopefully make this slightly clearer.
+            "AUTOVERSION_ni-labview-2017-x86": "aa4b25c0-a1f6-472e-8f76-32e406b7e44d (>=17.0.0) | 7a80ea72-c69d-4740-afbf-326544b9462c (>=17.1.0)",
       ]
 
       // Update the upper bound with each additional year release that uses the same package name format
       // Once we no longer need the legacy codes (i.e. the minimum supported VeriStand version is 2019) we
-      // can deprecate or remove this function, and just use the package names directly.
-      for (int year = 2019; year <= 2020; year++)
+      // can deprecate this function, and just use the package names and versions directly.
+      for (int year = 19; year <= 20; year++)
       {
-         def veristandString = "ni-veristand-${year}".toString()
-         substitutionStrings.put(veristandString, veristandString)
+         substitutionStrings.put(
+               "ni-veristand-20${year}".toString(),
+               "ni-veristand-20${year}".toString(),
+         )
       }
-      for (int year = 2018; year <= 2020; year++)
+      for (int year = 18; year <= 20; year++)
       {
-         def labviewString = "ni-labview-${year}-x86".toString()
-         substitutionStrings.put(labviewString, labviewString)
+         substitutionStrings.put(
+               "AUTOVERSION_ni-labview-20${year}-x86".toString(),
+               "ni-labview-20${year}-x86 (>=${year}.0.0)".toString(),
+         )
       }
 
       return substitutionStrings

--- a/src/ni/vsbuild/StringSubstitution.groovy
+++ b/src/ni/vsbuild/StringSubstitution.groovy
@@ -8,13 +8,48 @@ class StringSubstitution implements Serializable {
             "veristand_version": lvVersion,
             "labview_short_version": lvVersion.substring(lvVersion.length() - 2),
       ]
+      replacements << getLegacySubstitutionStrings()
       replacements << additionalReplacements
 
+      // Potentially run multiple times to allow nested replacement strings, e.g. "{ni-veristand-{veristand_version}}"
       def updatedText = text
-      replacements.each { expression, value ->
-         updatedText = updatedText.replaceAll("\\{$expression\\}", value)
+      def modified = true
+      while (modified)
+      {
+         def initialText = updatedText
+         replacements.each { expression, value ->
+            updatedText = updatedText.replaceAll("\\{$expression\\}", value)
+         }
+         modified = initialText != updatedText
       }
 
       return updatedText
+   }
+
+   private static Map<String, String> getLegacySubstitutionStrings()
+   {
+      def substitutionStrings = [
+            "ni-veristand-2016": "b8da4f0a-93cc-45f2-8fe8-5cf878017dc1",
+            "ni-veristand-2017": "89bad39c-da8d-4c78-ba1a-f5de0dafdc00",
+            "ni-veristand-2018": "d8f1d4e0-3466-42b0-92da-bdad96c42600",
+            "ni-labview-2016-x86": "7e1db25d-3f73-4659-a889-2b88330ebec6",
+            "ni-labview-2017-x86": "b0f7b394-1d4e-4350-9852-b5bdb2d64cb2",
+      ]
+
+      // Update the upper bound with each additional year release that uses the same package name format
+      // Once we no longer need the legacy codes (i.e. the minimum supported VeriStand version is 2019) we
+      // can deprecate or remove this function, and just use the package names directly.
+      for (int year = 2019; year <= 2020; year++)
+      {
+         def veristandString = "ni-veristand-${year}".toString()
+         substitutionStrings.put(veristandString, veristandString)
+      }
+      for (int year = 2018; year <= 2020; year++)
+      {
+         def labviewString = "ni-labview-${year}-x86".toString()
+         substitutionStrings.put(labviewString, labviewString)
+      }
+
+      return substitutionStrings
    }
 }


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-custom-device-build-tools/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Add the legacy product upgrade codes for VeriStand and LabVIEW as substitution variables. Also add trivial substitutions for versions that have proper package names, for convenience when using with the legacy codes. The substitutions are now processed multiple times (until no more substitutions occur), which allows for nesting.

Due to LabVIEW 2017 having an SP1 release (with a separate legacy upgrade code), we can't get away with just defining the upgrade codes per version. Instead, we have to provide a substitution that can handle providing multiple packages, which means handling the version number of those packages as well. This is unfortunately ugly, but it should be easy to remove once LabVIEW and VeriStand 2017 are no longer supported.

For example, `Depends: {AUTOVERSION_ni-labview-{labview_version}-x86}, {ni-veristand-{labview_version}} (>= {labview_short_version}.0.0)`

### Why should this Pull Request be merged?

Enables building nipkgs that depend on versions of LabVIEW and VeriStand which predate NI Package Manager.

By pushing this logic into the build tools, custom devices can easily add a dependency on a given version of VeriStand. This enables building more complex installers, such as having a top level package recommend multiple year versions of a custom device, where the end user will only see the versions corresponding to the versions of VeriStand they have installed.

More specifically, this should allow the VeriStand custom device top-level virtual package to recommend all year versions of the custom devices without installing unusable packages.

### What testing has been done?

I built the changes on https://github.com/ni/niveristand-routing-and-faulting-custom-device/tree/dev/dependencies and confirmed that the packages have the expected control files. I have not tried installing them due to time constraints.

The output packages are available at `\\nirvana\Measurements\VeriStandAddons\routing_and_faulting_custom_device\ni\export\dev\dependencies\Build 8\`.
