### PR TITLE
Fix config files not being correctly copied

### DIFF
--- a/vars/copyProjectConfig.groovy
+++ b/vars/copyProjectConfig.groovy
@@ -2,7 +2,7 @@
 // and versions, then replaces the versions based on the lvVersion
 def call(projectPath, lvVersion){
    echo "Copying configuration file for $projectPath"
-   configFileName = "$projectPath" + ".config"
+   def configFileName = "$projectPath" + ".config"
    
    def defaultVersion = ["$lvVersion": "${lvVersion}.0.0.0"]
    def assemblyVersions = readProperties defaults: defaultVersion, file: "niveristand-custom-device-build-tools/resources/assemblyVersions.properties"


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-custom-device-build-tools/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Creates a new object for the config file string to ensure the correct config file is copied when there are multiple projects to be built.

### Why should this Pull Request be merged?

The Routing and Faulting custom device build is currently failing because `configFileName` is not being declared as a separate object, so multiple calls can result in `configFileName` not matching `projectPath`.

### What testing has been done?

[Built the Routing and Faulting custom device](http://coordinator/blue/organizations/jenkins/VeriStand%2Fni%2Fniveristand-routing-and-faulting-custom-device/detail/master/112/pipeline) using the dev branch build tools and verified the correct files are being placed for each project.
