### PR TITLE
Fix parallel pipelines building for incorrect version

### DIFF
--- a/src/ni/vsbuild/Pipeline.groovy
+++ b/src/ni/vsbuild/Pipeline.groovy
@@ -10,7 +10,6 @@ class Pipeline implements Serializable {
 
    def script
    PipelineInformation pipelineInformation
-   def stages = []
 
    static class Builder implements Serializable {
 
@@ -113,9 +112,9 @@ class Pipeline implements Serializable {
                configuration.printInformation(script)
 
                def builder = new Builder(script, configuration, lvVersion, MANIFEST_FILE)
-               this.stages = builder.buildPipeline()
+               def stages = builder.buildPipeline()
 
-               executeStages()
+               executeStages(stages)
             }
          }
       }
@@ -125,7 +124,7 @@ class Pipeline implements Serializable {
       validateBuild()
    }
 
-   protected void executeStages() {
+   protected void executeStages(stages) {
       for (Stage stage : stages) {
          try {
             stage.execute()


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-custom-device-build-tools/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Assigns a new set of stages for each parallel process in the pipeline instead of using class data. This avoids the race condition that causes #50.

### Why should this Pull Request be merged?

Fixes #50 

### What testing has been done?

[Built](http://coordinator/blue/organizations/jenkins/VeriStand%2Fni%2Fniveristand-custom-device-message-library/detail/master/536/pipeline) a library to make sure all of the staging still works as expected.

The above build does not prove that the issue is fixed, but does verify no regression in build behavior from this change.
