### PR TITLE
Do not clobber existing build outputs

### DIFF
--- a/src/ni/vsbuild/BuildConfiguration.groovy
+++ b/src/ni/vsbuild/BuildConfiguration.groovy
@@ -30,11 +30,14 @@ class BuildConfiguration implements Serializable {
 
    static BuildConfiguration load(def script, String jsonFile, String lvVersion) {
       def config = script.readJSON file: jsonFile
+      return loadString(script, config.toString(), lvVersion)
+   }
 
+   static BuildConfiguration loadString(def script, String jsonConfig, String lvVersion) {
       // Convert the JSON to HashMaps instead of using the JsonObject
       // because the Pipeline security plugin disables lots of JsonObject
       // functionality that is required for this build system
-      def convertedJson = new JsonSlurperClassic().parseText(config.toString())
+      def convertedJson = new JsonSlurperClassic().parseText(jsonConfig)
 
       convertedJson = replaceTags(script, convertedJson, lvVersion)
 

--- a/src/ni/vsbuild/BuildConfiguration.groovy
+++ b/src/ni/vsbuild/BuildConfiguration.groovy
@@ -28,11 +28,6 @@ class BuildConfiguration implements Serializable {
       this.packageInfo = packageInfo
    }
 
-   static BuildConfiguration load(def script, String jsonFile, String lvVersion) {
-      def config = script.readJSON file: jsonFile
-      return loadString(script, config.toString(), lvVersion)
-   }
-
    static BuildConfiguration loadString(def script, String jsonConfig, String lvVersion) {
       // Convert the JSON to HashMaps instead of using the JsonObject
       // because the Pipeline security plugin disables lots of JsonObject

--- a/src/ni/vsbuild/Pipeline.groovy
+++ b/src/ni/vsbuild/Pipeline.groovy
@@ -10,6 +10,10 @@ class Pipeline implements Serializable {
 
    def script
    PipelineInformation pipelineInformation
+
+   // Call getJsonConfig(), instead of accessing this variable directly.
+   // getJsonConfig() uses this variable internally for caching,
+   // so it may or may not be set.
    private String jsonConfig
 
    static class Builder implements Serializable {
@@ -163,7 +167,7 @@ class Pipeline implements Serializable {
       return jsonConfig
    }
 
-   private boolean validateShouldBuildPipeline() {
+   private void validateShouldBuildPipeline() {
       // We do not want to rebuild if our output would clobber existing data.
       // This can happen if the Jenkins build numbers reset, or e.g. due to
       // multiple repositories unintentionally exporting to the same location.

--- a/vars/setLabVIEWPath.groovy
+++ b/vars/setLabVIEWPath.groovy
@@ -2,5 +2,4 @@ def call(lvVersion) {
    def programFiles = getWindowsVar("PROGRAMFILES(x86)")
    def baseVersion = (lvVersion =~ /^[0-9]+/).getAt(0)
    env."labviewPath_${lvVersion}" = "$programFiles\\National Instruments\\LabVIEW ${baseVersion}\\LabVIEW.exe"
-   bat "niveristand-custom-device-build-tools\\resources\\buildSetup.bat"
 }

--- a/vars/toml2json.groovy
+++ b/vars/toml2json.groovy
@@ -1,0 +1,3 @@
+def call() {
+   bat "niveristand-custom-device-build-tools\\resources\\buildSetup.bat"
+}


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-custom-device-build-tools/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Fail builds early if the archive step would overwrite existing data. This can happen if the Jenkins build numbers reset, or e.g. due to multiple repositories unintentionally exporting to the same location.

Also refactor the `build.toml` processing to only convert toml -> json once, and then re-use the json in memory. 

### Why should this Pull Request be merged?

We have seen issues with Jenkins losing the build numbers and silently overwriting build outputs.

### What testing has been done?

Built a custom device successfully, and then renamed that build output to the next build number. The subsequent build failed early as expected.