### PR TITLE
Build packages for pull requests that modify package-related files

### DIFF
--- a/resources/get_changed_files.py
+++ b/resources/get_changed_files.py
@@ -1,0 +1,22 @@
+import git_utilities
+import json
+
+
+def main(target):
+    output = [filename for _, filename in git_utilities.get_changed_files(args.target)]
+    print(json.dumps(output))
+
+
+if __name__ == "__main__":
+    import argparse
+    
+    parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+    parser.add_argument(
+        "--target",
+        help="Target branch or ref to generate a list of changed files against",
+        default="origin/master"
+    )
+
+    args = parser.parse_args()
+
+    main(args.target)

--- a/resources/git_utilities.py
+++ b/resources/git_utilities.py
@@ -1,0 +1,18 @@
+import re
+import subprocess
+
+def get_changed_files(target_ref):
+    """
+    Get files which have changed compared to the target ref.
+
+    :param target_ref: The git ref to check for changed files against
+    :return: Tuples of the form (status, filename) where status is either "A" or "M", depending on whether the file was added or modified.
+    """
+    diff_args = ["git", "diff", "--name-status", "--diff-filter=AM", target_ref + "...", "HEAD"]
+    diff_output = subprocess.check_output(diff_args).decode("utf-8")
+
+    # https://regex101.com/r/EFVDVV/2
+    diff_regex = re.compile(r"^([AM])\s+(.*)$", re.MULTILINE)
+
+    for match in re.finditer(diff_regex, diff_output):
+        yield match.group(1), match.group(2)

--- a/resources/labview_diff.py
+++ b/resources/labview_diff.py
@@ -8,6 +8,8 @@ import traceback
 from contextlib import contextmanager
 from os import path
 
+import git_utilities
+
 
 def diff_vi(old_vi, new_vi, output_dir, workspace, lv_version):
     """
@@ -90,14 +92,14 @@ def get_changed_labview_files(target_ref):
     :param target_ref: The git ref to check for changed files against
     :return: Tuples of the form (status, filename) where status is either "A" or "M", depending on whether the file was added or modified.
     """
-    diff_args = ["git", "diff", "--name-status", "--diff-filter=AM", target_ref + "...", "HEAD"]
-    diff_output = subprocess.check_output(diff_args).decode("utf-8")
+    changed_files = git_utilities.get_changed_files(target_ref)
 
-    # https://regex101.com/r/EFVDVV/1
-    diff_regex = re.compile(r"^([AM])\s+(.*\.vi[tm]?)$", re.MULTILINE)
+    # https://regex101.com/r/W3riqw/1
+    diff_regex = re.compile(r"^(.*\.vi[tm]?)$", re.MULTILINE)
 
-    for match in re.finditer(diff_regex, diff_output):
-        yield match.group(1), match.group(2)
+    for status, filename in changed_files:
+        if re.match(diff_regex, filename):
+            yield status, filename
 
 
 def diff_repo(workspace, output_dir, target_branch, lv_version):

--- a/src/ni/vsbuild/Pipeline.groovy
+++ b/src/ni/vsbuild/Pipeline.groovy
@@ -10,11 +10,8 @@ class Pipeline implements Serializable {
 
    def script
    PipelineInformation pipelineInformation
-
-   // Call getJsonConfig(), instead of accessing this variable directly.
-   // getJsonConfig() uses this variable internally for caching,
-   // so it may or may not be set.
-   private String jsonConfig
+   String jsonConfig
+   def changedFiles
 
    static class Builder implements Serializable {
 
@@ -22,13 +19,15 @@ class Pipeline implements Serializable {
       BuildConfiguration buildConfiguration
       String lvVersion
       String manifestFile
+      def changedFiles
       def stages = []
 
-      Builder(def script, BuildConfiguration buildConfiguration, String lvVersion, String manifestFile) {
+      Builder(def script, BuildConfiguration buildConfiguration, String lvVersion, String manifestFile, def changedFiles) {
          this.script = script
          this.buildConfiguration = buildConfiguration
          this.lvVersion = lvVersion
          this.manifestFile = manifestFile
+         this.changedFiles = changedFiles
       }
 
       def withCodegenStage() {
@@ -44,22 +43,53 @@ class Pipeline implements Serializable {
       }
 
       def withPackageStage() {
-         stages << new Package(script, buildConfiguration, lvVersion)
+         def packageStage = new Package(script, buildConfiguration, lvVersion)
+         
+         if (shouldBuildPackage(packageStage)) {
+            stages << packageStage
+         }
       }
 
       def withArchiveStage() {
          stages << new Archive(script, buildConfiguration, lvVersion, manifestFile)
       }
 
-      // The plan is to enable automatic merging from master to
-      // release or hotfix branch packages and not build packages
-      // for any other branches, including master. The version must
-      // be appended to the release or hotfix branch name after a
-      // dash (-) or slash (/).
-      def shouldBuildPackage() {
-         return buildConfiguration.packageInfo &&
+      def shouldBuildPackage(def packageStage) {
+         // The plan is to enable automatic merging from master to
+         // release or hotfix branch packages and not build packages
+         // for any other branches, including master. The version must
+         // be appended to the release or hotfix branch name after a
+         // dash (-) or slash (/).
+         def branchNameMatches = buildConfiguration.packageInfo &&
             (script.env.BRANCH_NAME.startsWith("release") ||
             script.env.BRANCH_NAME.startsWith("hotfix"))
+         if (branchNameMatches) {
+            return true
+         }
+
+         // We build packages for pull requests which modify files related
+         // to package building. Without this, testing these changes either
+         // requires the user to replay a previous build and force a package
+         // build, or to submit the changes and hope that they were correct.
+         // Since the build is exported as a pull request, other tooling
+         // shouldn't be checking for the package output.
+         if (script.env.CHANGE_ID) {
+            def configurationFiles = ["build.toml"] as Set
+            for (def pkg : packageStage.getPackages()) {
+               for (def file : pkg.getConfigurationFiles()) {
+                  configurationFiles.add(file.toLowerCase())
+               }
+            }
+
+            for (def file : changedFiles) {
+               if (file.toLowerCase() in configurationFiles) {
+                  script.echo "Running package stage because file \"${file}\" was changed."
+                  return true
+               }
+            }
+         }
+
+         return false
       }
 
       def buildPipeline() {
@@ -75,7 +105,7 @@ class Pipeline implements Serializable {
             withTestStage()
          }
 
-         if(shouldBuildPackage()) {
+         if(buildConfiguration.packageInfo) {
             withPackageStage()
          }
 
@@ -93,6 +123,7 @@ class Pipeline implements Serializable {
    }
 
    void execute() {
+      readBuildInformation()
       validateShouldBuildPipeline()
 
       // build dependencies before starting this pipeline
@@ -114,10 +145,10 @@ class Pipeline implements Serializable {
             script.node(nodeLabel) {
                setup(lvVersion)
 
-               def configuration = BuildConfiguration.loadString(script, getJsonConfig(), lvVersion)
+               def configuration = BuildConfiguration.loadString(script, jsonConfig, lvVersion)
                configuration.printInformation(script)
 
-               def builder = new Builder(script, configuration, lvVersion, MANIFEST_FILE)
+               def builder = new Builder(script, configuration, lvVersion, MANIFEST_FILE, changedFiles)
                def stages = builder.buildPipeline()
 
                executeStages(stages)
@@ -140,31 +171,27 @@ class Pipeline implements Serializable {
       }
    }
 
-   private String getJsonConfig() {
-      if (jsonConfig) {
-         return jsonConfig
-      }
-
+   private void readBuildInformation() {
       def manifest = script.readJSON text: '{}'
       def config
       script.node(pipelineInformation.nodeLabel) {
-         script.stage('Checkout_getJsonConfig') {
+         script.stage('Checkout_readBuildInformation') {
             script.deleteDir()
             script.echo 'Attempting to get source from repo.'
             script.timeout(time: 5, unit: 'MINUTES'){
                manifest['scm'] = script.checkout(script.scm)
             }
          }
-         script.stage('Setup_getJsonConfig') {
+         script.stage('Setup_readBuildInformation') {
             script.cloneBuildTools()
             script.toml2json()
 
             config = script.readJSON file: JSON_FILE
+            changedFiles = script.getChangedFiles()
          }
       }
 
       jsonConfig = config.toString()
-      return jsonConfig
    }
 
    private void validateShouldBuildPipeline() {
@@ -172,7 +199,7 @@ class Pipeline implements Serializable {
       // This can happen if the Jenkins build numbers reset, or e.g. due to
       // multiple repositories unintentionally exporting to the same location.
       def arbitraryLvVersion = pipelineInformation.lvVersions[0]
-      def configuration = BuildConfiguration.loadString(script, getJsonConfig(), arbitraryLvVersion)
+      def configuration = BuildConfiguration.loadString(script, jsonConfig, arbitraryLvVersion)
       if (!configuration.archive) {
          // We won't clobber anything if we aren't archiving
          return

--- a/src/ni/vsbuild/Pipeline.groovy
+++ b/src/ni/vsbuild/Pipeline.groovy
@@ -187,7 +187,9 @@ class Pipeline implements Serializable {
             script.toml2json()
 
             config = script.readJSON file: JSON_FILE
-            changedFiles = script.getChangedFiles()
+            if (script.env.CHANGE_ID) {
+               changedFiles = script.getChangedFiles()
+            }
          }
       }
 

--- a/src/ni/vsbuild/packages/AbstractPackage.groovy
+++ b/src/ni/vsbuild/packages/AbstractPackage.groovy
@@ -3,6 +3,7 @@ package ni.vsbuild.packages
 abstract class AbstractPackage implements Buildable {
 
    static final String INSTALLER_DIRECTORY = "installer"
+   static final String INVALID_VERSION = "0.0.0"
 
    def script
    def type
@@ -25,7 +26,21 @@ abstract class AbstractPackage implements Buildable {
 
    abstract void buildPackage(outputLocation)
 
+   // Returns files that affect the package build.
+   // This is used as a heuristic for determining whether
+   // to build packages for a pull request, and does not
+   // need to be exhaustive. This should not include the
+   // build.toml file or build output.
+   String[] getConfigurationFiles() {
+      return []
+   }
+
    protected def getBaseVersion() {
+      if (script.env.CHANGE_ID) {
+         // Assign an invalid version to pull requests
+         return INVALID_VERSION
+      }
+
       def baseVersion = script.env.BRANCH_NAME.split("[-/]")[1]
       def versionPartCount = baseVersion.tokenize(".").size()
 

--- a/src/ni/vsbuild/packages/Nipkg.groovy
+++ b/src/ni/vsbuild/packages/Nipkg.groovy
@@ -29,6 +29,10 @@ class Nipkg extends AbstractPackage {
       script.copyFiles(PACKAGE_DIRECTORY, "\"$outputLocation\"", [files: nipkgOutput])
    }
 
+   String[] getConfigurationFiles() {
+      return [this.controlFile, this.instructionsFile]
+   }
+
    @NonCPS
    private void createPayloadMap(packageInfo) {
       def payloadDir = packageInfo.get('payload_dir')

--- a/src/ni/vsbuild/stages/Package.groovy
+++ b/src/ni/vsbuild/stages/Package.groovy
@@ -5,25 +5,42 @@ import ni.vsbuild.packages.PackageFactory
 
 class Package extends AbstractStage {
 
+   private def packages
+
    Package(script, configuration, lvVersion) {
       super(script, 'Package', configuration, lvVersion)
    }
 
    void executeStage() {
-      def packageInfoCollection = []
+      for (def pkg : getPackages()) {
+         pkg.build()
+      }
+   }
 
+   def getPackages() {
+      // https://groovy-lang.org/operators.html#_direct_field_access_operator
+      if (!this.@packages) {
+         createPackages()
+      }
+
+      return this.@packages
+   }
+
+   private void createPackages() {
+      def packageInfoCollection = []
       // Developers can specify a single package [Package] or a collection of packages [[Package]].
       // Test the package information parameter and iterate as needed.
-      if (configuration.packageInfo in Collection) {
+      if (configuration.packageInfo instanceof Collection) {
          packageInfoCollection = configuration.packageInfo
       }
       else {
          packageInfoCollection.add(configuration.packageInfo)
       }
 
+      this.@packages = []
       for (def packageInfo : packageInfoCollection) {
          Buildable pkg = PackageFactory.createPackage(script, packageInfo, lvVersion)
-         pkg.build()
+         this.@packages.add(pkg)
       }
    }
 }

--- a/vars/getChangedFiles.groovy
+++ b/vars/getChangedFiles.groovy
@@ -1,0 +1,12 @@
+import groovy.json.JsonSlurperClassic
+
+// The bat command always returns the full command as well as the output
+// when returnStdout is true. To get the actual value, trim the leading and 
+// trailing whitespace, split the text to separate the command and stdout.
+def call() {
+   def resourcesDir = "${WORKSPACE}\\niveristand-custom-device-build-tools\\resources"
+
+   def commandOutput = bat returnStdout: true, script: "python ${resourcesDir}/get_changed_files.py"
+   changedFiles = commandOutput.trim().split("\n")[1]
+   return new JsonSlurperClassic().parseText(changedFiles)
+}


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-custom-device-build-tools/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Allow package steps to specify files that impact their output. This is used as a heuristic for rebuilding packages during pull requests. Currently this includes the `build.toml` file, and `control` and `instructions` files for nipkg steps.

### Why should this Pull Request be merged?

We currently either have to manually force packages to be built when testing, or blindly submit code and wait for a release branch to pick it up. This should give us more confidence when reviewing changes, without building packages for every change.

### What testing has been done?

I've built a few pull requests that both do and do not trigger installer builds; I intend to test it on Routing and Faulting (which builds multiple packages) before submitting.