### PR TITLE
Bold `_DEP_DIR` environment variable in documentation

### DIFF
--- a/docs/Advanced Usage.md
+++ b/docs/Advanced Usage.md
@@ -6,7 +6,7 @@ By default dependencies are always rebuilt. If the branch name being built on th
 
 This is not always the desired behavior. For a variety of reasons (e.g. the branch names do not match, the branches are part of pull requests which override the branch name in Jenkins, debugging with fixed dependencies), it may be beneficial to use an existing build of the dependencies, instead of rebuilding from source.
 
-The build tools support specifying a path to use for a given dependency's built artifacts as an environment variable. These environment variables can be easily set in a Jenkinsfile, either directly in the repository or when replaying a previous build.
+The build tools support specifying a path to use for a given dependency's built artifacts as an environment variable. These environment variables can be easily set in a Jenkinsfile, either directly in the repository or when replaying a previous build. The environment variable should be the dependency name suffixed with `_DEP_DIR`, and should refer to a path to a previous build's output.
 
 In the example below, `dependency-A` would use an existing built artifact, while `dependency-B` would be rebuilt as usual.
 

--- a/docs/Advanced Usage.md
+++ b/docs/Advanced Usage.md
@@ -6,7 +6,7 @@ By default dependencies are always rebuilt. If the branch name being built on th
 
 This is not always the desired behavior. For a variety of reasons (e.g. the branch names do not match, the branches are part of pull requests which override the branch name in Jenkins, debugging with fixed dependencies), it may be beneficial to use an existing build of the dependencies, instead of rebuilding from source.
 
-The build tools support specifying a path to use for a given dependency's built artifacts as an environment variable. These environment variables can be easily set in a Jenkinsfile, either directly in the repository or when replaying a previous build. The environment variable should be the dependency name suffixed with `_DEP_DIR`, and should refer to a path to a previous build's output.
+The build tools support specifying a path to use for a given dependency's built artifacts as an environment variable. These environment variables can be easily set in a Jenkinsfile, either directly in the repository or when replaying a previous build. The environment variable should be the dependency name suffixed with **`_DEP_DIR`**, and should refer to a path to a previous build's output.
 
 In the example below, `dependency-A` would use an existing built artifact, while `dependency-B` would be rebuilt as usual.
 


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-custom-device-build-tools/blob/master/CONTRIBUTING.md).


### What does this Pull Request accomplish?

Add a line to the documentation for overriding dependencies to highlight the environment variable name.

### Why should this Pull Request be merged?

It was pointed out that the `_DEP_DIR` environment variable name did not stand out in the code snippet. I couldn't get the text to be bolded in the code snippet, so this seemed the next best thing.

### What testing has been done?

N/A
