### PR TITLE
Allow creating `norebuild` file to prevent rebuilding a branch

### DIFF
--- a/src/ni/vsbuild/Pipeline.groovy
+++ b/src/ni/vsbuild/Pipeline.groovy
@@ -207,9 +207,14 @@ class Pipeline implements Serializable {
          return
       }
 
+      def archiveParentLocation = Archive.calculateArchiveParentLocation(script, configuration)
       def archiveLocation = Archive.calculateArchiveLocation(script, configuration)
       script.node(pipelineInformation.nodeLabel) {
          script.stage('validateShouldBuildPipeline') {
+            if (script.fileExists(archiveParentLocation + "\\norebuild")) {
+               script.failBuild("Refusing to build, norebuild file exists.")
+            }
+
             if (script.fileExists(archiveLocation)) {
                script.failBuild("Refusing to build, $archiveLocation already exists and would be overwritten.")
             }

--- a/src/ni/vsbuild/stages/Archive.groovy
+++ b/src/ni/vsbuild/stages/Archive.groovy
@@ -15,8 +15,8 @@ class Archive extends AbstractStage {
       this.manifestFile = manifestFile
    }
 
-   // Builds a string of the form <archiveLocation>\\export\\<branch>\\<build_number>
-   static String calculateArchiveLocation(script, BuildConfiguration configuration) {
+   // Builds a string of the form <archiveLocation>\\export\\<branch>
+   static String calculateArchiveParentLocation(script, BuildConfiguration configuration) {
       def organization = script.getComponentParts()['organization']
 
       // Organization may not exist for multibranch pipelines not using
@@ -30,8 +30,13 @@ class Archive extends AbstractStage {
 
       return ("${configuration.archive.get('archive_location')}\\" +
          "$organization" +
-         "export\\${script.env.BRANCH_NAME}\\" +
-         "Build ${script.currentBuild.number}").toString()
+         "export\\${script.env.BRANCH_NAME}\\").toString()
+   }
+
+   // Builds a string of the form <archiveLocation>\\export\\<branch>\\<build_number>
+   static String calculateArchiveLocation(script, BuildConfiguration configuration) {
+      return (calculateArchiveParentLocation(script, configuration)
+            + "\\Build ${script.currentBuild.number}").toString()
    }
 
    void executeStage() {

--- a/src/ni/vsbuild/stages/Archive.groovy
+++ b/src/ni/vsbuild/stages/Archive.groovy
@@ -30,7 +30,7 @@ class Archive extends AbstractStage {
 
       return ("${configuration.archive.get('archive_location')}\\" +
          "$organization" +
-         "export\\${script.env.BRANCH_NAME}\\").toString()
+         "export\\${script.env.BRANCH_NAME}").toString()
    }
 
    // Builds a string of the form <archiveLocation>\\export\\<branch>\\<build_number>


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-custom-device-build-tools/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Check for the existence of a `norebuild` file prior to starting a build which contains an archive step.

### Why should this Pull Request be merged?

We want a way to prevent new exports from being created for branches which are final.

### What testing has been done?

I ran a [build](http://coordinator/job/VeriStand/job/rtzoeller/job/niveristand-synchronization-custom-device/job/release%252F20.0/6/) on a release branch without the file and confirmed that it exported as expected. I created the `norebuild` file and confirmed the [build failed](http://coordinator/job/VeriStand/job/rtzoeller/job/niveristand-synchronization-custom-device/job/release%252F20.0/7).
