### PR TITLE
Replace exception throw blocked by Jenkins

### DIFF
--- a/src/ni/vsbuild/packages/Nipkg.groovy
+++ b/src/ni/vsbuild/packages/Nipkg.groovy
@@ -51,7 +51,7 @@ class Nipkg extends AbstractPackage {
       }
 
       if (!this.payloadMap) {
-         script.failBuild("Building an nipkg requires either 'payload_map'," +
+         script.failBuild("Building an nipkg requires either 'payload_map', " +
                "or 'payload_dir' and 'install_destination' to be specified.")
       }
    }


### PR DESCRIPTION
The Jenkins pipeline will not allow a script to throw RuntimeException.

- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-custom-device-build-tools/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Uses a Jenkins-acceptable way of failing the build and returning a message to the user.

### Why should this Pull Request be merged?

Jenkins does not show the error message if you try to throw an exception. Instead, you get an error message about scripts not being allowed to call the `RuntimeError` constructor, which gives you no clue why the build is actually failing.

### What testing has been done?

None. Will try to get a replay with an invalid `build.toml` to see results.
