### PR TITLE
change timeout from 5 to 10 minutes.

### DIFF
--- a/src/ni/vsbuild/Pipeline.groovy
+++ b/src/ni/vsbuild/Pipeline.groovy
@@ -178,7 +178,7 @@ class Pipeline implements Serializable {
          script.stage('Checkout_readBuildInformation') {
             script.deleteDir()
             script.echo 'Attempting to get source from repo.'
-            script.timeout(time: 5, unit: 'MINUTES'){
+            script.timeout(time: 10, unit: 'MINUTES'){
                manifest['scm'] = script.checkout(script.scm)
             }
          }


### PR DESCRIPTION
addresses https://github.com/ni/niveristand-custom-device-build-tools/issues/96#issue-664485295

- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-custom-device-build-tools/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Increases the timeout from 5 to 10 minutes for the script responsible for checking out repos from version control.

### Why should this Pull Request be merged?

To prevent future build failures of the DSF Custom Device Repo as this repo contains many files and consistently requires more than 4.5 minutes to check out from version control (#96)

### What testing has been done?

Verified that 10 minute timeout is sufficient for [DSF Custom Device](https://github.com/ni/niveristand-data-sharing-framework-custom-device) through review of build logs.
