### PR TITLE
Support target substitution in external deps

### DIFF
--- a/src/ni/vsbuild/steps/LvBuildStep.groovy
+++ b/src/ni/vsbuild/steps/LvBuildStep.groovy
@@ -37,7 +37,6 @@ abstract class LvBuildStep extends LvProjectStep {
 
       def dependencies = configuration.dependencies
       for(def key : dependencies.keySet()) {
-         //def dependencyDir = getDependencyPath(key)
          def dependency = dependencies.get(key)
          def copyLocation = dependency.get('copy_location')
          def libraries = dependency.get('libraries')


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-custom-device-build-tools/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Using local dependencies supports substituting the target in the library path. This change enables the same substitution for external dependencies instead of assuming the target is always immediately after the version.

### Why should this Pull Request be merged?

The Data Sharing Framework plugins depend on the DSF custom device, which exports libraries to subdirectories. This change enables the build tools to correctly build the path to the libraries to be copied.

### What testing has been done?

Ran a [replay build](https://nijenkins.amer.corp.natinst.com/blue/organizations/jenkins/NI%2Fniveristand-data-sharing-framework-custom-device-plugins/detail/PR-2/5/pipeline) with these changes to verify the files are correctly copied (the build failed, but the copy was good).
