### PR TITLE
Reformat python code to comply with ni-python-styleguide

### DIFF
--- a/resources/find_latest_directory.py
+++ b/resources/find_latest_directory.py
@@ -6,7 +6,7 @@ from os.path import exists, getmtime, join
 
 
 def find_latest_directory(base_path):
-    sub_dirs = glob.glob(join(base_path, '*'))
+    sub_dirs = glob.glob(join(base_path, "*"))
     if not sub_dirs:
         return None
     return max(sub_dirs, key=getmtime)

--- a/resources/get_changed_files.py
+++ b/resources/get_changed_files.py
@@ -9,12 +9,12 @@ def main(target):
 
 if __name__ == "__main__":
     import argparse
-    
+
     parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
     parser.add_argument(
         "--target",
         help="Target branch or ref to generate a list of changed files against",
-        default="origin/main"
+        default="origin/main",
     )
 
     args = parser.parse_args()

--- a/resources/git_utilities.py
+++ b/resources/git_utilities.py
@@ -1,6 +1,7 @@
 import re
 import subprocess
 
+
 def get_changed_files(target_ref):
     """
     Get files which have changed compared to the target ref.

--- a/resources/github_commenter.py
+++ b/resources/github_commenter.py
@@ -12,55 +12,65 @@ _moduleLogger = logging.getLogger(__name__)
 
 def _parse_options(args):
     import optparse
+
     parser = optparse.OptionParser("usage: %prog [options] TOKEN PICS PR INFO")
 
     # Setup parser
     parser.add_option(
-        "-t", "--token",
+        "-t",
+        "--token",
         dest="token",
         metavar="TOKEN",
-        help="Github Access token needed to perform write operations"
+        help="Github Access token needed to perform write operations",
     )
     parser.add_option(
-        "-d", "--pic-dir",
+        "-d",
+        "--pic-dir",
         dest="picDir",
         metavar="PICS",
-        help="Absolute path to the directory containing the pictures you want to upload"
+        help="Absolute path to the directory containing the pictures you want to upload",
     )
     parser.add_option(
-        "-p", "--pull-req",
+        "-p",
+        "--pull-req",
         dest="pr",
         metavar="PR",
-        help="Github pull request number where you want to comment"
+        help="Github pull request number where you want to comment",
     )
     parser.add_option(
-        "-i", "--info",
+        "-i",
+        "--info",
         dest="info",
         metavar="INFO",
-        help="Information about the org, repo, and pull request you are trying to use, e.g. 'ni/niveristand-custom-device-build-tools/PR-13'"
+        help="Information about the org, repo, and pull request you are trying to use, e.g. 'ni/niveristand-custom-device-build-tools/PR-13'",
     )
     parser.add_option(
-        "-r", "--pic-repo",
+        "-r",
+        "--pic-repo",
         dest="picRepo",
         metavar="REPO",
-        help="The owner and repo to post to on github, e.g. 'theSloopJohnB/thesloopjohnb' for https://github.com/theSloopJohnB/thesloopjohnb"
+        help="The owner and repo to post to on github, e.g. 'theSloopJohnB/thesloopjohnb' for https://github.com/theSloopJohnB/thesloopjohnb",
     )
 
     debugGroup = optparse.OptionGroup(parser, "Debug")
     debugGroup.add_option(
-        "-v", "--verbose",
-        action="count", dest="verbosity", default=0,
-        help="Turn on verbose output. (Useful if you really care to see what the tool is doing at all times.)"
+        "-v",
+        "--verbose",
+        action="count",
+        dest="verbosity",
+        default=0,
+        help="Turn on verbose output. (Useful if you really care to see what the tool is doing at all times.)",
     )
     debugGroup.add_option(
-        "-q", "--quiet",
-        action="count", dest="quietness", default=0,
-        help="Don't print anything to the module logger."
+        "-q",
+        "--quiet",
+        action="count",
+        dest="quietness",
+        default=0,
+        help="Don't print anything to the module logger.",
     )
     debugGroup.add_option(
-        "--test",
-        action="store_true", dest="test", default=False,
-        help="Run doctests then quit."
+        "--test", action="store_true", dest="test", default=False, help="Run doctests then quit."
     )
     parser.add_option_group(debugGroup)
 
@@ -96,15 +106,18 @@ def _parse_options(args):
 def main(args):
     options, loggingLevel = _parse_options(args)
 
-    logFormat = '(%(asctime)s) %(levelname)-5s %(name)s.%(funcName)s: %(message)s'
+    logFormat = "(%(asctime)s) %(levelname)-5s %(name)s.%(funcName)s: %(message)s"
     logging.basicConfig(level=loggingLevel, format=logFormat)
 
     if options.test:
         import doctest
+
         print(doctest.testmod())
         return
     else:
-        post_pictures_to_pull_request(options.token, options.picDir, options.info, options.pr, options.picRepo)
+        post_pictures_to_pull_request(
+            options.token, options.picDir, options.info, options.pr, options.picRepo
+        )
 
     return 0
 

--- a/resources/labview_diff.py
+++ b/resources/labview_diff.py
@@ -28,11 +28,16 @@ def diff_vi(old_vi, new_vi, output_dir, workspace, lv_version):
 
     command_args = [
         "LabVIEWCLI.exe",
-        "-LabVIEWPath", version_path,
-        "-AdditionalOperationDirectory", workspace + r"\niveristand-custom-device-build-tools\lv\operations\\",
-        "-OperationName", "DiffVI",
-        "-NewVI", new_vi,
-        "-OutputDir", output_dir,
+        "-LabVIEWPath",
+        version_path,
+        "-AdditionalOperationDirectory",
+        workspace + r"\niveristand-custom-device-build-tools\lv\operations\\",
+        "-OperationName",
+        "DiffVI",
+        "-NewVI",
+        new_vi,
+        "-OutputDir",
+        output_dir,
     ]
 
     if old_vi:
@@ -42,7 +47,7 @@ def diff_vi(old_vi, new_vi, output_dir, workspace, lv_version):
     try:
         subprocess.check_call(command_args)
     except subprocess.CalledProcessError:
-        print("Failed to diff \"{0}\" and \"{1}\".".format(old_vi, new_vi))
+        print('Failed to diff "{0}" and "{1}".'.format(old_vi, new_vi))
         traceback.print_exc()
 
         with open(output_dir + "\\diff_failures.txt", "a+") as file:
@@ -54,7 +59,9 @@ def labview_path_from_year(year):
     if env_key in os.environ:
         return os.environ[env_key]
 
-    return r"{0}\National Instruments\LabVIEW {1}\LabVIEW.exe".format(os.environ["ProgramFiles(x86)"], year)
+    return r"{0}\National Instruments\LabVIEW {1}\LabVIEW.exe".format(
+        os.environ["ProgramFiles(x86)"], year
+    )
 
 
 def export_repo(target_ref):
@@ -109,7 +116,9 @@ def diff_repo(workspace, output_dir, target_branch, lv_version):
         for status, filename in diffs:
             if status == "A":
                 print("Diffing added file: " + filename)
-                diff_vi(None, path.abspath(filename), path.abspath(output_dir), workspace, lv_version)
+                diff_vi(
+                    None, path.abspath(filename), path.abspath(output_dir), workspace, lv_version
+                )
             elif status == "M":
                 print("Diffing modified file: " + filename)
                 # LabVIEW won't let us load two files with the same name into memory,
@@ -119,7 +128,13 @@ def diff_repo(workspace, output_dir, target_branch, lv_version):
                 old_file = path.join(directory.name, filename)
                 copied_file = path.join(path.dirname(old_file), "_COPY_" + path.basename(filename))
                 shutil.copy(old_file, copied_file)
-                diff_vi(copied_file, path.abspath(filename), path.abspath(output_dir), workspace, lv_version)
+                diff_vi(
+                    copied_file,
+                    path.abspath(filename),
+                    path.abspath(output_dir),
+                    workspace,
+                    lv_version,
+                )
             else:
                 print("Unknown file status: " + filename)
 
@@ -131,20 +146,16 @@ if __name__ == "__main__":
     parser.add_argument(
         "workspace",
         help="Directory which contains the `niveristand-custom-device-build-tools` repository "
-             "(as opposed to the `niveristand-custom-device-build-tools` repository itself)"
+        "(as opposed to the `niveristand-custom-device-build-tools` repository itself)",
     )
+    parser.add_argument("output_dir", help="Directory in which to generate output")
     parser.add_argument(
-        "output_dir",
-        help="Directory in which to generate output"
-    )
-    parser.add_argument(
-        "labview_version",
-        help="Year version of LabVIEW you wish to use for diffing"
+        "labview_version", help="Year version of LabVIEW you wish to use for diffing"
     )
     parser.add_argument(
         "--target",
         help="Target branch or ref the diff is being generated against",
-        default="origin/main"
+        default="origin/main",
     )
 
     args = parser.parse_args()

--- a/resources/merge_release_branch.py
+++ b/resources/merge_release_branch.py
@@ -17,10 +17,10 @@ def integrate_release(url, version, working_directory):
         and is a git repository, the repository will be updated in place instead of cloning from scratch.
     """
 
-    assert url.endswith(".git"), \
-        'Expected url to end with ".git"'
-    assert match(r"^\d+\.\d+(\.\d+)?$", version), \
-        'Version must be in format "x.y" or "x.y.z"'  # https://regex101.com/r/xqyo5X/2
+    assert url.endswith(".git"), 'Expected url to end with ".git"'
+    assert match(
+        r"^\d+\.\d+(\.\d+)?$", version
+    ), 'Version must be in format "x.y" or "x.y.z"'  # https://regex101.com/r/xqyo5X/2
     working_directory_path = Path(working_directory)
 
     previous_working_directory = getcwd()

--- a/resources/needs_rebuild.py
+++ b/resources/needs_rebuild.py
@@ -14,14 +14,14 @@ def validate_versions_exist(base_dir, versions):
 
 
 def validate_commits_match(base_dir, commit, version):
-    manifest_file = join(base_dir, str(version), 'installer', 'manifest.json')
+    manifest_file = join(base_dir, str(version), "installer", "manifest.json")
     if not exists(manifest_file):
         return False
 
     with open(manifest_file) as f:
         data = json.load(f)
 
-    previous_commit = data['scm']['GIT_COMMIT']
+    previous_commit = data["scm"]["GIT_COMMIT"]
     if previous_commit.lower() != commit.lower():
         return False
 

--- a/resources/post_pictures_to_pull_request.py
+++ b/resources/post_pictures_to_pull_request.py
@@ -11,11 +11,11 @@ _moduleLogger = logging.getLogger(__name__)
 
 
 def _create_header(token):
-    return {'Authorization': 'token %s' % token.strip()}
+    return {"Authorization": "token %s" % token.strip()}
 
 
 def _read_picture(file_name):
-    with open(file_name, 'rb') as text:
+    with open(file_name, "rb") as text:
         return base64.b64encode(text.read()).decode()
 
 
@@ -24,16 +24,16 @@ def _post_file(file_data, folder, file_name, header, picRepo):
     new_file_data = json.dumps({"message": "commit message", "content": file_data})
 
     # post a picture to a repo
-    url = 'https://api.github.com/repos/%s/contents/%s/%s' % (picRepo, folder, file_name)
+    url = "https://api.github.com/repos/%s/contents/%s/%s" % (picRepo, folder, file_name)
 
     r = requests.put(url, data=new_file_data, headers=header)
     if r.ok:
-        _moduleLogger.info('Response code: %s', r.status_code)
+        _moduleLogger.info("Response code: %s", r.status_code)
     else:
-        _moduleLogger.error('Bad response url: %s', url)
-        _moduleLogger.error('Bad response code: %s', r.status_code)
-        _moduleLogger.error('Bad response text: %s', r.text)
-    return r.json()['content']['download_url']
+        _moduleLogger.error("Bad response url: %s", url)
+        _moduleLogger.error("Bad response code: %s", r.status_code)
+        _moduleLogger.error("Bad response text: %s", r.text)
+    return r.json()["content"]["download_url"]
 
 
 def _post_comment_to_pr(urlPicPairs, diffFailures, pullRequestInfo, prNumber, header):
@@ -64,21 +64,22 @@ Notice something funny? Help fix me on [my GitHub repo.](https://github.com/ni/n
     data = json.dumps({"body": body})
     r = requests.post(url, data=data, headers=header)
     if r.ok:
-        _moduleLogger.info('Response code: %s', r.status_code)
+        _moduleLogger.info("Response code: %s", r.status_code)
     else:
-        _moduleLogger.error('Bad response url: %s', url)
-        _moduleLogger.error('Bad response code: %s', r.status_code)
-        _moduleLogger.error('Bad response text: %s', r.text)
+        _moduleLogger.error("Bad response url: %s", url)
+        _moduleLogger.error("Bad response code: %s", r.status_code)
+        _moduleLogger.error("Bad response text: %s", r.text)
 
 
 def post_pictures_to_pull_request(token, localPicfileDirectory, pullRequestInfo, prNumber, picRepo):
-    print("post_pictures_to_pull_request: ###, {0}, {1}, {2}, {3}".format(localPicfileDirectory,
-                                                                          pullRequestInfo,
-                                                                          prNumber,
-                                                                          picRepo))
+    print(
+        "post_pictures_to_pull_request: ###, {0}, {1}, {2}, {3}".format(
+            localPicfileDirectory, pullRequestInfo, prNumber, picRepo
+        )
+    )
     header = _create_header(token)
     pics = [f for f in os.listdir(localPicfileDirectory) if f.endswith(".png")]
-    folder = pullRequestInfo + '/' + datetime.datetime.now().strftime('%Y-%m-%d/%H:%M:%S')
+    folder = pullRequestInfo + "/" + datetime.datetime.now().strftime("%Y-%m-%d/%H:%M:%S")
     picUrls = []
     for pic in pics:
         picData = _read_picture(os.path.join(localPicfileDirectory, pic))

--- a/resources/toml2json.py
+++ b/resources/toml2json.py
@@ -7,8 +7,8 @@ file = sys.argv[1]
 parsed_toml = toml.load(file)
 
 base_path, file_name = os.path.split(file)
-json_file_name = os.path.splitext(file_name)[0] + '.json'
+json_file_name = os.path.splitext(file_name)[0] + ".json"
 
 print("Writing build description to", json_file_name)
-with open(json_file_name, 'w') as outfile:
+with open(json_file_name, "w") as outfile:
     json.dump(parsed_toml, outfile, indent=3)


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-custom-device-build-tools/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Reformat our python code to comply with https://github.com/ni/python-styleguide.

This was done automatically using `black` with a configured line length of 100.

### Why should this Pull Request be merged?

This is a nonfunctional change that updates our code to use a standardized convention.

### What testing has been done?

None - `black` is a well tested tool which should not impact functionality.
