### PR TITLE
Log active control file name in nipkg build step

### DIFF
--- a/src/ni/vsbuild/packages/Nipkg.groovy
+++ b/src/ni/vsbuild/packages/Nipkg.groovy
@@ -23,9 +23,13 @@ class Nipkg extends AbstractPackage {
    }
 
    void buildPackage(outputLocation) {
+      script.echo "Staging files for $controlFile"
       stageFiles()
 
+      script.echo "Building nipkg for $controlFile"
       def nipkgOutput = script.nipkgBuild(PACKAGE_DIRECTORY, PACKAGE_DIRECTORY)
+      
+      script.echo "Copying files for $controlFile"
       script.copyFiles(PACKAGE_DIRECTORY, "\"$outputLocation\"", [files: nipkgOutput])
    }
 


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-custom-device-build-tools/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Log intermediate steps for building nipkgs, including the control file name.

### Why should this Pull Request be merged?

@Karl-G1 and I were confused by the lack of logs in this area - it wasn't clear if a package was not being built, or if was just not being archived correctly.

Adding the control file name to the output should make it easier to grep for things.

### What testing has been done?

- [x] Building a PR which should have multiple packages built and verifying the output.

![image](https://user-images.githubusercontent.com/573497/97500932-749c5000-193e-11eb-8f53-2c02fb2116fa.png)
