### PR TITLE
Create a .finished file when the build succeeds

### DIFF
--- a/src/ni/vsbuild/Pipeline.groovy
+++ b/src/ni/vsbuild/Pipeline.groovy
@@ -321,8 +321,19 @@ class Pipeline implements Serializable {
                   script.failBuild("Failed to build version $version. See issue: https://github.com/ni/niveristand-custom-device-build-tools/issues/50")
                }
             }
+
+            createFinishedFile(exportDir)
          }
       }
+   }
+
+   // Create a file indicating the build is finished.
+   // If this file exists, the build was successful.
+   // If this file does not exist, the build was either unsuccessful
+   // or is still in progress -- in either case, the archive should
+   // not be consumed.
+   private void createFinishedFile(exportDir) {
+      script.bat "type nul > \"$exportDir\\.finished\""
    }
 
    private String getArbitraryVersionConfiguration() {


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-custom-device-build-tools/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Create a `.finished` file when the build succeeds, so other processes can check this status.

### Why should this Pull Request be merged?

We want the feed build tool to only pull from finished builds.

### What testing has been done?

Ran a build with these changes and confirmed the file was added after all LV versions were built.
