### PR TITLE
Fix build error with git 2.29

### DIFF
--- a/resources/git_utilities.py
+++ b/resources/git_utilities.py
@@ -9,7 +9,7 @@ def get_changed_files(target_ref):
     :param target_ref: The git ref to check for changed files against
     :return: Tuples of the form (status, filename) where status is either "A" or "M", depending on whether the file was added or modified.
     """
-    diff_args = ["git", "diff", "--name-status", "--diff-filter=AM", target_ref + "...", "HEAD"]
+    diff_args = ["git", "diff", "--name-status", "--diff-filter=AM", target_ref + "..."]
     diff_output = subprocess.check_output(diff_args).decode("utf-8")
 
     # https://regex101.com/r/EFVDVV/2


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-custom-device-build-tools/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Remove unnecessary `HEAD` argument.

### Why should this Pull Request be merged?

Builds are failing because git is returning the help text, rather than expected output.

git previously accepted input of the form `git diff origin/main... HEAD`, but now fails on the space. The expected input is `git diff origin/main...HEAD`, but we can omit `HEAD` entirely.

### What testing has been done?

Re-ran the failed build and made it past the point of failure.
