### PR TITLE
Don't fail build on directory cleanup failure

### DIFF
--- a/vars/diffPipeline.groovy
+++ b/vars/diffPipeline.groovy
@@ -2,6 +2,8 @@
 
 import org.jenkinsci.plugins.workflow.steps.FlowInterruptedException
 import hudson.AbortException
+import java.nio.file.FileSystemException
+import jenkins.util.io.CompositeIOException
 
 //note: this script assumes that it will be invoked from another script after that script has defined the necessary parameters
 

--- a/vars/diffPipeline.groovy
+++ b/vars/diffPipeline.groovy
@@ -52,7 +52,12 @@ def call(lvVersion) {
          }
       }
       stage('Cleanup') {
-         deleteDir()
+         try {
+            deleteDir()
+         }
+         catch (CompositeIOException | FileSystemException e) {
+               echo "Directory cleanup failed"
+         }
       }
    }
 }


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-custom-device-build-tools/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Ignore error following VI diff if directory cleanup fails. Subsequent builds will clean the directory before doing anything, so this failure is inconsequential.

### Why should this Pull Request be merged?

Our build nodes had some software upgrades over which we have no control. These upgrades have caused failures deleting files following diffs because the file system still has these files locked. This failure should not fail an entire build.

### What testing has been done?

Ran a replay of a failing build. Verified I see the failure string printed but the build still passes.
