### PR TITLE
Fix installer archiving issue

### DIFF
--- a/src/ni/vsbuild/stages/Archive.groovy
+++ b/src/ni/vsbuild/stages/Archive.groovy
@@ -45,11 +45,12 @@ class Archive extends AbstractStage {
 
       script.echo "Archiving build to $archiveLocation"
       def buildOutputDir = configuration.archive.get('build_output_dir')
-      def installerOutputDir = "$buildOutputDir\\$INSTALLER_DIR"
 
       if(script.fileExists(BuildConfiguration.STAGING_DIR)) {
          buildOutputDir = BuildConfiguration.STAGING_DIR
       }
+
+      def installerOutputDir = "$buildOutputDir\\$INSTALLER_DIR"
 
       def versionedArchive = "$archiveLocation\\${lvVersion.lvRuntimeVersion}"
       def versionedArchitectureArchive = "$versionedArchive\\${lvVersion.architecture}"

--- a/src/ni/vsbuild/stages/Archive.groovy
+++ b/src/ni/vsbuild/stages/Archive.groovy
@@ -5,6 +5,7 @@ import ni.vsbuild.BuildConfiguration
 class Archive extends AbstractStage {
 
    private static final String MANIFEST_ARCHIVE_DIR = 'installer'
+   private static final String INSTALLER_DIR = 'installer
 
    private String archiveLocation
    private String manifestFile
@@ -44,6 +45,7 @@ class Archive extends AbstractStage {
 
       script.echo "Archiving build to $archiveLocation"
       def buildOutputDir = configuration.archive.get('build_output_dir')
+      def installerOutputDir = "$buildOutputDir\\$INSTALLER_DIR"
 
       if(script.fileExists(BuildConfiguration.STAGING_DIR)) {
          buildOutputDir = BuildConfiguration.STAGING_DIR
@@ -51,7 +53,9 @@ class Archive extends AbstractStage {
 
       def versionedArchive = "$archiveLocation\\${lvVersion.lvRuntimeVersion}"
       def versionedArchitectureArchive = "$versionedArchive\\${lvVersion.architecture}"
+      def versionedInstallerDir = "$versionedArchive\\$INSTALLER_DIR"
       script.copyFiles(buildOutputDir, versionedArchitectureArchive, [exclusions: getInstallerExtensions()])
+      script.copyFiles(installerOutputDir, versionedInstallerDir, [files: getInstallerExtensions()])
 
       archiveManifest(versionedArchive)
 
@@ -74,7 +78,6 @@ class Archive extends AbstractStage {
       if(!script.fileExists("$versionedInstallerDir\\$manifestFileName")) {
          def manifestDirectory = manifestFile.take(splitIndex)
          script.copyFiles(manifestDirectory, versionedInstallerDir, [files: manifestFileName])
-         script.copyFiles(manifestDirectory, versionedInstallerDir, [files: getInstallerExtensions()])
       }
    }
 


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-custom-device-build-tools/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Fixes an issue where build outputs to locations other than `Built` cause installers to not be archived. This was introduced in #115 

### Why should this Pull Request be merged?

No installers are archived correctly even though they are built.

### What testing has been done?

Ran a replay of a build where installers were not copied and now they are.
