### PR TITLE
fix typo by adding back in a closing '

### DIFF
--- a/src/ni/vsbuild/stages/Archive.groovy
+++ b/src/ni/vsbuild/stages/Archive.groovy
@@ -5,7 +5,7 @@ import ni.vsbuild.BuildConfiguration
 class Archive extends AbstractStage {
 
    private static final String MANIFEST_ARCHIVE_DIR = 'installer'
-   private static final String INSTALLER_DIR = 'installer
+   private static final String INSTALLER_DIR = 'installer'
 
    private String archiveLocation
    private String manifestFile


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-custom-device-build-tools/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

fix typo

### Why should this Pull Request be merged?

should fix this build error:
>org.codehaus.groovy.control.MultipleCompilationErrorsException: startup failed:
file:/F:/Jenkins/jobs/NI/jobs/niverista.97m919c3ad81.om-device/branches/PR-54/builds/4/libs/vs-build-tools/src/ni/vsbuild/stages/Archive.groovy: 8: expecting ''', found '\r' @ line 8, column 58.
   ing INSTALLER_DIR = 'installer
                                 ^

### What testing has been done?

None yet. Hoping this will unblock PR builds
