### PR TITLE
Enable building steps based on bitness

### DIFF
--- a/docs/Toml Help.md
+++ b/docs/Toml Help.md
@@ -130,6 +130,7 @@ Key | Description | Required
 `target` | name of the target that owns the `build_spec` | **YES**
 `build_spec` | name of the specification to be built | **YES**
 `dependency_target` | path prepended to a dependency's `libraries` key to fetch the correct version of a dependency | **NO**
+`bitness` | limit this step to build only for the provided bitness, either 32 or 64 | **NO**
 `output_dir` | path prepended to a dependency's `libraries` key | **NO** (**_deprecated_**)
 `output_libraries` | array of libraries to be copied to the `output_dir` | **NO** (**_deprecated_**)
 
@@ -144,6 +145,17 @@ type = 'lvBuildSpec'
 project = '{first}' # uses the value 'src\first.lvproj' from the example in the Projects section of this document
 target = 'My Computer'
 build_spec = 'Configuration Release'
+```
+
+Execute a build spec with no dependencies and no alteration of the output directory, but only for a 32-bit LabVIEW version.
+```
+[[build.steps]]
+name = 'Configuration Library'
+type = 'lvBuildSpec'
+project = '{first}' # uses the value 'src\first.lvproj' from the example in the Projects section of this document
+target = 'My Computer'
+build_spec = 'Configuration Release'
+bitness = '32'
 ```
 
 Execute a build spec and require the 64-bit Linux dependency libraries.
@@ -182,6 +194,7 @@ Key | Description | Required
 `project` | reference to the project table in the projects section of `build.toml`  | **YES**
 `build_spec` | name of the specification to be built | **YES**
 `dependency_target` | path prepended to a dependency's `libraries` key to fetch the correct version of a dependency | **NO**
+`bitness` | limit this step to build only for the provided bitness, either 32 or 64 | **NO**
 
 
 ###### Example
@@ -192,6 +205,16 @@ name = 'Engine Libraries'
 type = 'lvBuildSpecAllTargets'
 project = '{first}' # uses the value 'src\first.lvproj' from the example in the Projects section of this document
 build_spec = 'Engine Release'
+```
+
+Execute a build spec with no dependencies, but only for a 64-bit LabVIEW version.
+```
+[[build.steps]]
+name = 'Engine Libraries'
+type = 'lvBuildSpecAllTargets'
+project = '{first}' # uses the value 'src\first.lvproj' from the example in the Projects section of this document
+build_spec = 'Engine Release'
+bitness = '64'
 ```
 
 Execute a build spec and require the 64-bit Linux dependency libraries.
@@ -214,6 +237,7 @@ The LvBuildAll step builds all build specs under all targets in the specified pr
 Key | Description | Required
 -|-|-
 `project` | reference to the project table in the projects section of `build.toml`  | **YES**
+`bitness` | limit this step to build only for the provided bitness, either 32 or 64 | **NO**
 
 ###### Example
 ```

--- a/src/ni/vsbuild/Architecture.groovy
+++ b/src/ni/vsbuild/Architecture.groovy
@@ -10,10 +10,12 @@ enum Architecture {
       this.programFilesVar = value
    }
 
+   @NonCPS
    static Architecture bitnessToArchitecture(int bitness) {
       return bitness == 32 ? Architecture.x86 : Architecture.x64
    }
 
+   @NonCPS
    static int architectureToBitness(Architecture arch) {
       return arch == Architecture.x86 ? 32 : 64
    }

--- a/src/ni/vsbuild/Architecture.groovy
+++ b/src/ni/vsbuild/Architecture.groovy
@@ -9,4 +9,12 @@ enum Architecture {
    Architecture(String value) {
       this.programFilesVar = value
    }
+
+   static Architecture bitnessToArchitecture(int bitness) {
+      return bitness == 32 ? Architecture.x86 : Architecture.x64
+   }
+
+   static int architectureToBitness(Architecture arch) {
+      return arch == Architecture.x86 ? 32 : 64
+   }
 }

--- a/src/ni/vsbuild/LabviewBuildVersion.groovy
+++ b/src/ni/vsbuild/LabviewBuildVersion.groovy
@@ -9,7 +9,7 @@ class LabviewBuildVersion implements Serializable {
 
    LabviewBuildVersion(String lvRuntimeVersion, int bitness = 32) {
       this.lvRuntimeVersion = lvRuntimeVersion
-      this.architecture = bitness == 32 ? Architecture.x86 : Architecture.x64
+      this.architecture = Architecture.bitnessToArchitecture(bitness)
    }
 
    public String getLabviewPath(def script) {
@@ -21,7 +21,7 @@ class LabviewBuildVersion implements Serializable {
    @NonCPS
    @Override
    public String toString() {
-      def bitness = architecture == Architecture.x86 ? "(32-bit)" : "(64-bit)"
-      return "$lvRuntimeVersion $bitness"
+      def bitness = Architecture.architectureToBitness(architecture)
+      return "$lvRuntimeVersion (${bitness}-bit)"
    }
 }

--- a/src/ni/vsbuild/steps/LvBuildStep.groovy
+++ b/src/ni/vsbuild/steps/LvBuildStep.groovy
@@ -17,6 +17,10 @@ abstract class LvBuildStep extends LvProjectStep {
    }
 
    void executeStep(BuildConfiguration configuration) {
+      if(!supportedArchitecture()) {
+         return
+      }
+
       copyDependencies(configuration)
 
       def resolvedProject = resolveProject(configuration)

--- a/src/ni/vsbuild/steps/LvStep.groovy
+++ b/src/ni/vsbuild/steps/LvStep.groovy
@@ -5,22 +5,22 @@ import ni.vsbuild.Architecture
 abstract class LvStep extends AbstractStep {
 
    def lvVersion
-   def architecture
+   def bitness
 
    LvStep(script, mapStep, lvVersion) {
       super(script, mapStep)
       this.lvVersion = lvVersion
-      this.architecture = Architecture.bitnessToArchitecture(this.outputDir = mapStep.get('bitness'))
+      this.bitness = mapStep.get('bitness')
    }
 
    // Return true if the current build architecture matches
    // the desired architecture for the step. If no specific
    // architecture is defined for the step, return true.
    public boolean supportedArchitecture() {
-      if(!architecture) {
+      if(!bitness) {
          return true
       }
 
-      return lvVersion.architecture == this.architecture
+      return lvVersion.architecture == Architecture.bitnessToArchitecture(bitness as Integer)
    }
 }

--- a/src/ni/vsbuild/steps/LvStep.groovy
+++ b/src/ni/vsbuild/steps/LvStep.groovy
@@ -1,11 +1,26 @@
 package ni.vsbuild.steps
 
+import ni.vsbuild.Architecture
+
 abstract class LvStep extends AbstractStep {
 
    def lvVersion
+   def architecture
 
    LvStep(script, mapStep, lvVersion) {
       super(script, mapStep)
       this.lvVersion = lvVersion
+      this.architecture = Architecture.bitnessToArchitecture(this.outputDir = mapStep.get('bitness'))
+   }
+
+   // Return true if the current build architecture matches
+   // the desired architecture for the step. If no specific
+   // architecture is defined for the step, return true.
+   public boolean supportedArchitecture() {
+      if(!architecture) {
+         return true
+      }
+
+      return lvVersion.architecture == this.architecture
    }
 }


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-custom-device-build-tools/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Allows a `build.toml` file to designate a specific bitness for running a given build step. If no bitness is provided, the step will run for any build. If **bitness** is provided, either 32 or 64, the build step will only be run in cases where a LabVIEW of that bitness is used.

### Why should this Pull Request be merged?

The Scan Engine and EtherCAT custom device will need to build only certain build specs for 32-bit LabVIEW due to dependencies not being available in 64-bit LabVIEW.

### What testing has been done?

Ran builds with no bitness specified, 32 specified, and 64 specified, and verified build specs were only run for the correct bitness.
