### PR TITLE
Add variables to help with builds of differing bitness

### DIFF
--- a/src/ni/vsbuild/BuildConfiguration.groovy
+++ b/src/ni/vsbuild/BuildConfiguration.groovy
@@ -30,7 +30,7 @@ class BuildConfiguration implements Serializable {
       this.notificationInfo = notificationInfo
    }
 
-   static BuildConfiguration loadString(def script, String jsonConfig, String lvVersion) {
+   static BuildConfiguration loadString(def script, String jsonConfig, LabviewBuildVersion lvVersion) {
       // Convert the JSON to HashMaps instead of using the JsonObject
       // because the Pipeline security plugin disables lots of JsonObject
       // functionality that is required for this build system

--- a/src/ni/vsbuild/Pipeline.groovy
+++ b/src/ni/vsbuild/Pipeline.groovy
@@ -46,7 +46,7 @@ class Pipeline implements Serializable {
 
       def withPackageStage() {
          def packageStage = new Package(script, buildConfiguration, lvVersion)
-         
+
          if (shouldBuildPackage(packageStage)) {
             stages << packageStage
          }
@@ -234,7 +234,7 @@ class Pipeline implements Serializable {
    private void runBuild() {
       def builders = [:]
 
-      for(String version : pipelineInformation.lvVersions) {
+      for(LabviewBuildVersion version : pipelineInformation.lvVersions) {
 
          // need to bind the variable before the closure - can't do 'for (version in lvVersions)'
          def lvVersion = version
@@ -248,7 +248,7 @@ class Pipeline implements Serializable {
             script.node(nodeLabel) {
                setup(lvVersion)
 
-               def configuration = BuildConfiguration.loadString(script, jsonConfig, lvVersion.lvRuntimeVersion)
+               def configuration = BuildConfiguration.loadString(script, jsonConfig, lvVersion)
                configuration.printInformation(script)
 
                def builder = new Builder(script, configuration, lvVersion, MANIFEST_FILE, changedFiles)
@@ -305,7 +305,7 @@ class Pipeline implements Serializable {
    // If this issue is encountered, the build will still show success even
    // though an export for the desired version is not actually created.
    // We should fail the build instead of returning false success.
-   private void validateBuild() {      
+   private void validateBuild() {
       String nodeLabel = ''
       if (pipelineInformation.nodeLabel?.trim()) {
          nodeLabel = pipelineInformation.nodeLabel
@@ -338,7 +338,7 @@ class Pipeline implements Serializable {
 
    private String getArbitraryVersionConfiguration() {
       def arbitraryLvVersion = pipelineInformation.lvVersions[0]
-      def configuration = BuildConfiguration.loadString(script, jsonConfig, arbitraryLvVersion.lvRuntimeVersion)
+      def configuration = BuildConfiguration.loadString(script, jsonConfig, arbitraryLvVersion)
       return configuration
    }
 }

--- a/src/ni/vsbuild/StringSubstitution.groovy
+++ b/src/ni/vsbuild/StringSubstitution.groovy
@@ -3,10 +3,14 @@ package ni.vsbuild
 class StringSubstitution implements Serializable {
 
    public static String replaceStrings(text, lvVersion, additionalReplacements = [:]) {
+      def year = lvVersion.lvRuntimeVersion
+      def architecture = lvVersion.architecture
       def replacements = [
-            "labview_version": lvVersion,
-            "veristand_version": lvVersion,
-            "labview_short_version": lvVersion.substring(lvVersion.length() - 2),
+            "labview_version": year,
+            "veristand_version": year,
+            "labview_short_version": year.substring(year.length() - 2),
+            "pkg_x86_bitness_suffix": architecture == Architecture.x86 ? "-x86" : "",
+            "nipaths_64_bitness_suffix": architecture == Architecture.x64 ? "64" : "",
       ]
       replacements << getLegacySubstitutionStrings()
       replacements << additionalReplacements
@@ -28,6 +32,8 @@ class StringSubstitution implements Serializable {
       return updatedText
    }
 
+   // TODO: These are deprecated as we target VeriStand 2019 as a minimum version,
+   // but we need to remove their usage in custom devices before removing the definitions.
    private static Map<String, String> getLegacySubstitutionStrings()
    {
       def substitutionStrings = [

--- a/src/ni/vsbuild/packages/Nipkg.groovy
+++ b/src/ni/vsbuild/packages/Nipkg.groovy
@@ -28,7 +28,7 @@ class Nipkg extends AbstractPackage {
 
       script.echo "Building nipkg for $controlFile"
       def nipkgOutput = script.nipkgBuild(PACKAGE_DIRECTORY, PACKAGE_DIRECTORY)
-      
+
       script.echo "Copying files for $controlFile"
       script.copyFiles(PACKAGE_DIRECTORY, "\"$outputLocation\"", [files: nipkgOutput])
    }
@@ -111,7 +111,7 @@ class Nipkg extends AbstractPackage {
       def fullVersion = getFullVersion()
 
       def additionalReplacements = ['nipkg_version': fullVersion, 'display_version': baseVersion]
-      return StringSubstitution.replaceStrings(text, lvVersion.lvRuntimeVersion, additionalReplacements)
+      return StringSubstitution.replaceStrings(text, lvVersion, additionalReplacements)
    }
 
    private void stagePayload() {

--- a/src/ni/vsbuild/steps/LvBuildStep.groovy
+++ b/src/ni/vsbuild/steps/LvBuildStep.groovy
@@ -48,13 +48,13 @@ abstract class LvBuildStep extends LvProjectStep {
          for(def library : libraries) {
             def dependencyDir = getDependencyPath(key, library)
             def libraryName = getLibraryName(library)
-            def substitutedLibraryPath = StringSubstitution.replaceStrings(library, lvVersion.lvRuntimeVersion, ['target' : dependencyTarget])
+            def substitutedLibraryPath = StringSubstitution.replaceStrings(library, lvVersion, ['target' : dependencyTarget])
             script.bat "copy /y \"$dependencyDir\\$substitutedLibraryPath\" \"$copyLocation\\$libraryName\""
          }
       }
    }
 
-   protected void stageLibraries(String outputDir, BuildConfiguration configuration) {      
+   protected void stageLibraries(String outputDir, BuildConfiguration configuration) {
       def buildOutputDir = configuration.archive.get('build_output_dir')
       def stageDir = BuildConfiguration.STAGING_DIR
 


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-custom-device-build-tools/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Define the following variables:

| Variable | 32-bit value | 64-bit value |
|---|---|---|
| `pkg_x86_bitness_suffix` | `-x86` | |
| `nipaths_64_bitness_suffix` | | `64` |

### Why should this Pull Request be merged?

These variables will allow packages to install to the correct bitness NI-Paths and depend on the correct bitness packages.

### What testing has been done?

Built https://github.com/ni/niveristand-routing-and-faulting-custom-device/pull/266 and confirmed that the R+F LabVIEW package could be installed, and that the VIs and palettes appeared correctly in LabVIEW 64-bit.
