### PR TITLE
Build bitness binaries based on LabVIEW version

### DIFF
--- a/docs/Toml Help.md
+++ b/docs/Toml Help.md
@@ -195,6 +195,7 @@ Key | Description | Required
 `build_spec` | name of the specification to be built | **YES**
 `dependency_target` | path prepended to a dependency's `libraries` key to fetch the correct version of a dependency | **NO**
 `bitness` | limit this step to build only for the provided bitness, either 32 or 64 | **NO**
+`bitness_versions` | list of LabVIEW versions where the `bitness` key applies | **NO**
 
 
 ###### Example
@@ -216,6 +217,18 @@ project = '{first}' # uses the value 'src\first.lvproj' from the example in the 
 build_spec = 'Engine Release'
 bitness = '64'
 ```
+
+Execute a build spec with no dependencies, but only for a 64-bit if LabVIEW version is 2020 or 2021. For other versions, build regardless of bitness.
+```
+[[build.steps]]
+name = 'Engine Libraries'
+type = 'lvBuildSpecAllTargets'
+project = '{first}' # uses the value 'src\first.lvproj' from the example in the Projects section of this document
+build_spec = 'Engine Release'
+bitness = '64'
+bitness_versions = ['2020', '2021']
+```
+
 
 Execute a build spec and require the 64-bit Linux dependency libraries.
 This is a little weird because there shouldn't be multiple build specs of the same name if specific dependencies are required, but it still works. Using lvBuildSpec would be more concise.

--- a/src/ni/vsbuild/steps/LvStep.groovy
+++ b/src/ni/vsbuild/steps/LvStep.groovy
@@ -6,21 +6,36 @@ abstract class LvStep extends AbstractStep {
 
    def lvVersion
    def bitness
+   def bitnessVersions
 
    LvStep(script, mapStep, lvVersion) {
       super(script, mapStep)
       this.lvVersion = lvVersion
       this.bitness = mapStep.get('bitness')
+      this.bitnessVersions = mapStep.get('bitness_versions')
    }
 
    // Return true if the current build architecture matches
    // the desired architecture for the step. If no specific
    // architecture is defined for the step, return true.
    public boolean supportedArchitecture() {
-      if(!bitness) {
+      if (!bitness) {
          return true
       }
 
+      // If bitness is specified, check for the existence of bitness-specific
+      // versions entry.
+      if (bitnessVersions) {
+
+         // If the current runtime version is not one of the bitness-specific
+         // versions, ignore bitness and always build.
+         if (!bitnessVersions.contains(lvVersion.lvRuntimeVersion)) {
+            return true
+         }
+      }
+
+      //If no version-specific entry or the current version is found in the list
+      //of specific versions, check the bitness of the current version.
       return lvVersion.architecture == Architecture.bitnessToArchitecture(bitness as Integer)
    }
 }


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-custom-device-build-tools/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Enables a `build.toml` file to specify to which versions of LabVIEW the bitness configuration should apply.

If no `bitness` is specified, the build step executes for any bitness.
If only `bitness` is specified, the build step executes only for that bitness in any LabVIEW version.
If `bitness` and` bitness_versions` are specified, the build step executes:
 - for any `bitness` if the current version is not listed in `bitness_versions`
 - for only the specified `bitness` if the current version is listed in `bitness_versions`

### Why should this Pull Request be merged?

The Scan Engine modules and custom device need to build some build specs for only 32-bit and some for only 64-bit in LabVIEW 2021 due to lack of driver support. However, for older versions (2019 and 2020), all build specs need to build and will all be 32-bit. This change supports both of these use cases on an individual build step basis.

### What testing has been done?

Built the Scan Engine modules and custom device and verified all necessary binaries are created for 2019-2021 and for the correct bitnesses. Verified output with @Karl-G1 .
