### PR TITLE
Enable setting conditional symbol using LV bitness

### DIFF
--- a/src/ni/vsbuild/steps/LvSetConditionalSymbolStep.groovy
+++ b/src/ni/vsbuild/steps/LvSetConditionalSymbolStep.groovy
@@ -30,9 +30,18 @@ class LvSetConditionalSymbolStep extends LvProjectStep {
       def expressionParts = condition.split()
       def leftSide = expressionParts[0]
       def operator = expressionParts[1]
-      def rightSide = expressionParts[2]
 
-      leftSide = this."$leftSide"
+      // All this nonsense because Jenkins security won't let me slice the list.
+      // If https://issues.jenkins.io/browse/JENKINS-52036 is ever fixed (it says it
+      // is, but the PR was closed without being merged), this whole section becomes
+      // def rightSide = expressionParts[2..-1].join(' ')
+      def rightSide = ''
+      for (int i = 2; i < expressionParts.size(); i++) {
+         rightSide = "$rightSide ${expressionParts[i]}"
+      }
+      rightSide = rightSide.trim()
+
+      leftSide = this."$leftSide".toString()
 
       if(operator.equals("<")) {
          return leftSide < rightSide


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-custom-device-build-tools/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Allows users to specify a bitness for the LabVIEW version when setting a conditional symbol in `build.toml`.

### Why should this Pull Request be merged?

The Scan Engine and EtherCAT custom device needs to set a conditional symbol in the project only if a build is using LabVIEW 2021 64-bit. [Scan Engine EtherCAT PR 185](https://github.com/ni/niveristand-scan-engine-ethercat-custom-device/pull/185).

### What testing has been done?

Built the Scan Engine dev branch with the change and verified the correct symbol was set for each version of LabVIEW.
