### PR TITLE
Enable building packages for multiple bitnesses

### DIFF
--- a/src/ni/vsbuild/Pipeline.groovy
+++ b/src/ni/vsbuild/Pipeline.groovy
@@ -338,7 +338,7 @@ class Pipeline implements Serializable {
 
       script.node(nodeLabel) {
          executePostArchiveStages()
-         validateBuild()
+         createFinishedFile()
       }
    }
 
@@ -348,32 +348,14 @@ class Pipeline implements Serializable {
       }
    }
 
-   // This method is here to catch builds with issue 50:
-   // https://github.com/ni/niveristand-custom-device-build-tools/issues/50
-   // If this issue is encountered, the build will still show success even
-   // though an export for the desired version is not actually created.
-   // We should fail the build instead of returning false success.
-   private void validateBuild() {
-      script.stage("Validation") {
-         script.echo("Validating build output.")
-         def component = script.getComponentParts()['repo']
-         def exportDir = script.env."${component}_DEP_DIR"
-         pipelineInformation.lvVersions.each { version ->
-            if(!script.fileExists("$exportDir\\${version.lvRuntimeVersion}")) {
-               script.failBuild("Failed to build version $version. See issue: https://github.com/ni/niveristand-custom-device-build-tools/issues/50")
-            }
-         }
-
-         createFinishedFile(exportDir)
-      }
-   }
-
    // Create a file indicating the build is finished.
    // If this file exists, the build was successful.
    // If this file does not exist, the build was either unsuccessful
    // or is still in progress -- in either case, the archive should
    // not be consumed.
-   private void createFinishedFile(exportDir) {
+   private void createFinishedFile() {
+      def component = script.getComponentParts()['repo']
+      def exportDir = script.env."${component}_DEP_DIR"
       script.bat "type nul > \"$exportDir\\.finished\""
    }
 

--- a/src/ni/vsbuild/Pipeline.groovy
+++ b/src/ni/vsbuild/Pipeline.groovy
@@ -278,7 +278,7 @@ class Pipeline implements Serializable {
    }
 
    private void runPostArchiveBuild() {
-      def stages = postArchiveStages.entrySet().collect { it.value }
+      def stages = postArchiveStages.values()
       script.echo("postArchiveStages: $stages")
    }
 

--- a/src/ni/vsbuild/packages/DefaultPackageStrategy.groovy
+++ b/src/ni/vsbuild/packages/DefaultPackageStrategy.groovy
@@ -14,4 +14,8 @@ class DefaultPackageStrategy implements PackageStrategy {
                                              && !(it.get('multi_bitness_versions').contains(lvVersion.lvRuntimeVersion)))
       }
    }
+
+   def createNipkgPayloadMap(payloadMap) {
+      return payloadMap
+   }
 }

--- a/src/ni/vsbuild/packages/DefaultPackageStrategy.groovy
+++ b/src/ni/vsbuild/packages/DefaultPackageStrategy.groovy
@@ -2,7 +2,16 @@ package ni.vsbuild.packages
 
 class DefaultPackageStrategy implements PackageStrategy {
 
-   void filterPackageCollection(packageCollection) {
-      packageCollection.removeAll { it.get('multi_bitness') }
+   def lvVersion
+
+   DefaultPackageStrategy(lvVersion) {
+      this.lvVersion = lvVersion
+   }
+
+   def filterPackageCollection(packageCollection) {
+      return packageCollection.findAll { !(it.get('multi_bitness')) \
+                                          || ((it.get('multi_bitness_versions')) \
+                                             && !(it.get('multi_bitness_versions').contains(lvVersion.lvRuntimeVersion)))
+      }
    }
 }

--- a/src/ni/vsbuild/packages/DefaultPackageStrategy.groovy
+++ b/src/ni/vsbuild/packages/DefaultPackageStrategy.groovy
@@ -15,8 +15,11 @@ class DefaultPackageStrategy implements PackageStrategy {
       }
    }
 
-   @NonCPS
-   def createNipkgPayloadMap(payloadMap) {
+   def getOutputDirectory(script, outputDir) {
+      return outputDir
+   }
+
+   def createNipkgPayloadMap(script, payloadMap, outputDir) {
       return payloadMap
    }
 }

--- a/src/ni/vsbuild/packages/DefaultPackageStrategy.groovy
+++ b/src/ni/vsbuild/packages/DefaultPackageStrategy.groovy
@@ -8,6 +8,10 @@ class DefaultPackageStrategy implements PackageStrategy {
       this.lvVersion = lvVersion
    }
 
+   // Returns all packages with a configuration where
+   // multi_bitness is not defined OR
+   // if multi_bitness is defined, but the current LabVIEW version
+   // does not match any of the versions specified for multi-bitness packaging.
    def filterPackageCollection(packageCollection) {
       return packageCollection.findAll { !(it.get('multi_bitness')) \
                                           || ((it.get('multi_bitness_versions')) \

--- a/src/ni/vsbuild/packages/DefaultPackageStrategy.groovy
+++ b/src/ni/vsbuild/packages/DefaultPackageStrategy.groovy
@@ -15,6 +15,7 @@ class DefaultPackageStrategy implements PackageStrategy {
       }
    }
 
+   @NonCPS
    def createNipkgPayloadMap(payloadMap) {
       return payloadMap
    }

--- a/src/ni/vsbuild/packages/DefaultPackageStrategy.groovy
+++ b/src/ni/vsbuild/packages/DefaultPackageStrategy.groovy
@@ -1,0 +1,8 @@
+package ni.vsbuild.packages
+
+class DefaultPackageStrategy implements PackageStrategy {
+
+   void filterPackageCollection(packageCollection) {
+      packageCollection.removeAll { it.get('multi_bitness') }
+   }
+}

--- a/src/ni/vsbuild/packages/Nipkg.groovy
+++ b/src/ni/vsbuild/packages/Nipkg.groovy
@@ -48,16 +48,19 @@ class Nipkg extends AbstractPackage {
       // https://stackoverflow.com/questions/39145121/why-i-cannot-get-exactly-the-same-gstring-as-was-put-to-map-in-groovy
       def installDestination = packageInfo.get("${lvVersion.lvRuntimeVersion}_install_destination".toString()) ?: packageInfo.get('install_destination')
 
+      def configurationPayloadMap
       if (payloadDir) {
-         this.payloadMap = [(payloadDir): installDestination]
+         configurationPayloadMap = [(payloadDir): installDestination]
       } else {
-         this.payloadMap = packageInfo.get('payload_map')
+         configurationPayloadMap = packageInfo.get('payload_map')
       }
 
-      if (!this.payloadMap) {
+      if (!configurationPayloadMap) {
          script.failBuild("Building an nipkg requires either 'payload_map', " +
                "or 'payload_dir' and 'install_destination' to be specified.")
       }
+
+      this.payloadMap = strategy.createNipkgPayloadMap(configurationPayloadMap)
    }
 
    // This method is responsible for setting up the directory and file

--- a/src/ni/vsbuild/packages/Nipkg.groovy
+++ b/src/ni/vsbuild/packages/Nipkg.groovy
@@ -60,7 +60,7 @@ class Nipkg extends AbstractPackage {
                "or 'payload_dir' and 'install_destination' to be specified.")
       }
 
-      this.payloadMap = strategy.createNipkgPayloadMap(configurationPayloadMap)
+      this.payloadMap = configurationPayloadMap
    }
 
    // This method is responsible for setting up the directory and file

--- a/src/ni/vsbuild/packages/Nipkg.groovy
+++ b/src/ni/vsbuild/packages/Nipkg.groovy
@@ -31,7 +31,7 @@ class Nipkg extends AbstractPackage {
       script.echo "Building nipkg for $controlFile"
       def nipkgOutput = script.nipkgBuild(PACKAGE_DIRECTORY, PACKAGE_DIRECTORY)
 
-      def outputDirectory = this.strategy.getOutputDirectory(outputLocation)
+      def outputDirectory = this.strategy.getOutputDirectory(script, outputLocation)
       script.echo "Copying files for $controlFile"
       script.copyFiles(PACKAGE_DIRECTORY, "\"$outputDirectory\"", [files: nipkgOutput])
    }

--- a/src/ni/vsbuild/packages/Nipkg.groovy
+++ b/src/ni/vsbuild/packages/Nipkg.groovy
@@ -33,7 +33,7 @@ class Nipkg extends AbstractPackage {
 
       def outputDirectory = this.strategy.getOutputDirectory(script, outputLocation)
       script.echo "Copying files for $controlFile"
-      script.copyFiles(PACKAGE_DIRECTORY, "\"$outputDirectory\"", [files: nipkgOutput])
+      script.copyFiles(PACKAGE_DIRECTORY, outputDirectory, [files: nipkgOutput])
    }
 
    String[] getConfigurationFiles() {

--- a/src/ni/vsbuild/packages/Nipkg.groovy
+++ b/src/ni/vsbuild/packages/Nipkg.groovy
@@ -15,9 +15,9 @@ class Nipkg extends AbstractPackage {
    def controlFile
    def instructionsFile
 
-   Nipkg(script, packageInfo, lvVersion) {
+   Nipkg(script, packageInfo, lvVersion, strategy) {
       super(script, packageInfo, lvVersion)
-      this.createPayloadMap(packageInfo)
+      this.createPayloadMap(packageInfo, strategy)
       this.controlFile = packageInfo.get('control_file') ?: CONTROL_FILE_NAME
       this.instructionsFile = packageInfo.get('instructions_file') ?: INSTRUCTIONS_FILE_NAME
    }
@@ -38,7 +38,7 @@ class Nipkg extends AbstractPackage {
    }
 
    @NonCPS
-   private void createPayloadMap(packageInfo) {
+   private void createPayloadMap(packageInfo, strategy) {
       def payloadDir = packageInfo.get('payload_dir')
       // Yes, I'm calling toString() on what appears to be a string, but is not actually
       // java.lang.String. Instead, the interpolated string is a groovy.lang.GString.
@@ -60,7 +60,7 @@ class Nipkg extends AbstractPackage {
                "or 'payload_dir' and 'install_destination' to be specified.")
       }
 
-      this.payloadMap = configurationPayloadMap
+      this.payloadMap = strategy.createNipkgPayloadMap(configurationPayloadMap)
    }
 
    // This method is responsible for setting up the directory and file

--- a/src/ni/vsbuild/packages/PackageFactory.groovy
+++ b/src/ni/vsbuild/packages/PackageFactory.groovy
@@ -2,11 +2,11 @@ package ni.vsbuild.packages
 
 class PackageFactory implements Serializable {
 
-   static Buildable createPackage(script, packageInfo, lvVersion) {
+   static Buildable createPackage(script, packageInfo, lvVersion, strategy) {
       def type = packageInfo.get('type')
 
       if(type == 'nipkg') {
-         return new Nipkg(script, packageInfo, lvVersion)
+         return new Nipkg(script, packageInfo, lvVersion, strategy)
       }
       else if(type == 'zip') {
          return new Zip(script, packageInfo, lvVersion)

--- a/src/ni/vsbuild/packages/PackageStrategy.groovy
+++ b/src/ni/vsbuild/packages/PackageStrategy.groovy
@@ -1,0 +1,7 @@
+package ni.vsbuild.packages
+
+interface PackageStrategy extends Serializable {
+
+   void filterPackageCollection(packageCollection)
+
+}

--- a/src/ni/vsbuild/packages/PackageStrategy.groovy
+++ b/src/ni/vsbuild/packages/PackageStrategy.groovy
@@ -8,6 +8,7 @@ interface PackageStrategy extends Serializable {
    // remove/removeAll.
    def filterPackageCollection(packageCollection)
 
+   @NonCPS
    def createNipkgPayloadMap(payloadMap)
 
 }

--- a/src/ni/vsbuild/packages/PackageStrategy.groovy
+++ b/src/ni/vsbuild/packages/PackageStrategy.groovy
@@ -8,7 +8,8 @@ interface PackageStrategy extends Serializable {
    // remove/removeAll.
    def filterPackageCollection(packageCollection)
 
-   @NonCPS
-   def createNipkgPayloadMap(payloadMap)
+   def getOutputDirectory(script, outputDir)
+
+   def createNipkgPayloadMap(script, payloadMap, outputDir)
 
 }

--- a/src/ni/vsbuild/packages/PackageStrategy.groovy
+++ b/src/ni/vsbuild/packages/PackageStrategy.groovy
@@ -2,6 +2,10 @@ package ni.vsbuild.packages
 
 interface PackageStrategy extends Serializable {
 
-   void filterPackageCollection(packageCollection)
+   // This method must return a new list instead of modifying
+   // packageCollection directly due to the way the json object
+   // stored in the BuildConfiguration is manipulated if using
+   // remove/removeAll.
+   def filterPackageCollection(packageCollection)
 
 }

--- a/src/ni/vsbuild/packages/PackageStrategy.groovy
+++ b/src/ni/vsbuild/packages/PackageStrategy.groovy
@@ -8,4 +8,6 @@ interface PackageStrategy extends Serializable {
    // remove/removeAll.
    def filterPackageCollection(packageCollection)
 
+   def createNipkgPayloadMap(payloadMap)
+
 }

--- a/src/ni/vsbuild/packages/PostArchivePackageStrategy.groovy
+++ b/src/ni/vsbuild/packages/PostArchivePackageStrategy.groovy
@@ -1,0 +1,17 @@
+package ni.vsbuild.packages
+
+class PostArchivePackageStrategy implements PackageStrategy {
+
+   def lvVersion
+
+   PostArchivePackageStrategy(lvVersion) {
+      this.lvVersion = lvVersion
+   }
+
+   void filterPackageCollection(packageCollection) {
+      packageCollection.removeAll { !(it.get('multi_bitness')) \
+                                    || ((it.get('multi_bitness_versions')) \
+                                       && !(it.get('multi_bitness_versions').contains(lvVersion.lvRuntimeVersion)))
+      }
+   }
+}

--- a/src/ni/vsbuild/packages/PostArchivePackageStrategy.groovy
+++ b/src/ni/vsbuild/packages/PostArchivePackageStrategy.groovy
@@ -8,10 +8,10 @@ class PostArchivePackageStrategy implements PackageStrategy {
       this.lvVersion = lvVersion
    }
 
-   void filterPackageCollection(packageCollection) {
-      packageCollection.removeAll { !(it.get('multi_bitness')) \
-                                    || ((it.get('multi_bitness_versions')) \
-                                       && !(it.get('multi_bitness_versions').contains(lvVersion.lvRuntimeVersion)))
+   def filterPackageCollection(packageCollection) {
+      return packageCollection.findAll { it.get('multi_bitness') \
+                                          &&  (!(it.get('multi_bitness_versions')) \
+                                             || (it.get('multi_bitness_versions').contains(lvVersion.lvRuntimeVersion)))
       }
    }
 }

--- a/src/ni/vsbuild/packages/PostArchivePackageStrategy.groovy
+++ b/src/ni/vsbuild/packages/PostArchivePackageStrategy.groovy
@@ -15,6 +15,7 @@ class PostArchivePackageStrategy implements PackageStrategy {
       }
    }
 
+   @NonCPS
    def createNipkgPayloadMap(payloadMap) {
       return payloadMap
    }

--- a/src/ni/vsbuild/packages/PostArchivePackageStrategy.groovy
+++ b/src/ni/vsbuild/packages/PostArchivePackageStrategy.groovy
@@ -1,5 +1,7 @@
 package ni.vsbuild.packages
 
+import ni.vsbuild.Architecture
+
 class PostArchivePackageStrategy implements PackageStrategy {
 
    def lvVersion
@@ -15,8 +17,19 @@ class PostArchivePackageStrategy implements PackageStrategy {
       }
    }
 
-   @NonCPS
-   def createNipkgPayloadMap(payloadMap) {
-      return payloadMap
+   def getOutputDirectory(script, outputDir) {
+      def component = script.getComponentParts()['repo']
+      def archiveLocation = script.env."${component}_DEP_DIR"
+      return "$archiveLocation\\${lvVersion.lvRuntimeVersion}"
+   }
+
+   def createNipkgPayloadMap(script, payloadMap, outputDir) {
+      def newOutputDir = getOutputDirectory(script, outputDir)
+      def newMap = [:]
+      for (def key : payloadMap.keySet()) {
+         Architecture.values().each { newMap[key.replace(outputDir, "$newOutputDir\\$it")] = payloadMap[key] }
+      }
+
+      return newMap
    }
 }

--- a/src/ni/vsbuild/packages/PostArchivePackageStrategy.groovy
+++ b/src/ni/vsbuild/packages/PostArchivePackageStrategy.groovy
@@ -18,18 +18,23 @@ class PostArchivePackageStrategy implements PackageStrategy {
    }
 
    def getOutputDirectory(script, outputDir) {
-      def component = script.getComponentParts()['repo']
-      def archiveLocation = script.env."${component}_DEP_DIR"
-      return "$archiveLocation\\${lvVersion.lvRuntimeVersion}"
+      def baseOutputDirectory = getBaseOutputDirectory(script)
+      return "$baseOutputDirectory\\${AbstractPackage.INSTALLER_DIRECTORY}"
    }
 
    def createNipkgPayloadMap(script, payloadMap, outputDir) {
-      def newOutputDir = getOutputDirectory(script, outputDir)
+      def newOutputDir = getBaseOutputDirectory(script)
       def newMap = [:]
       for (def key : payloadMap.keySet()) {
          Architecture.values().each { newMap[key.replace(outputDir, "$newOutputDir\\$it")] = payloadMap[key] }
       }
 
       return newMap
+   }
+
+   private def getBaseOutputDirectory(script) {
+      def component = script.getComponentParts()['repo']
+      def archiveLocation = script.env."${component}_DEP_DIR"
+      return "$archiveLocation\\${lvVersion.lvRuntimeVersion}"
    }
 }

--- a/src/ni/vsbuild/packages/PostArchivePackageStrategy.groovy
+++ b/src/ni/vsbuild/packages/PostArchivePackageStrategy.groovy
@@ -14,4 +14,8 @@ class PostArchivePackageStrategy implements PackageStrategy {
                                              || (it.get('multi_bitness_versions').contains(lvVersion.lvRuntimeVersion)))
       }
    }
+
+   def createNipkgPayloadMap(payloadMap) {
+      return payloadMap
+   }
 }

--- a/src/ni/vsbuild/packages/PostArchivePackageStrategy.groovy
+++ b/src/ni/vsbuild/packages/PostArchivePackageStrategy.groovy
@@ -10,6 +10,12 @@ class PostArchivePackageStrategy implements PackageStrategy {
       this.lvVersion = lvVersion
    }
 
+   // Returns all packages with a configuration where
+   // multi_bitness is defined AND
+   // the current LabVIEW version matches one of the versions
+   // specified for multi-bitness packaging.
+   // If no versions are specified, include the package with the
+   // assumption that multi_bitness exists for ALL versions.
    def filterPackageCollection(packageCollection) {
       return packageCollection.findAll { it.get('multi_bitness') \
                                           &&  (!(it.get('multi_bitness_versions')) \

--- a/src/ni/vsbuild/stages/Package.groovy
+++ b/src/ni/vsbuild/stages/Package.groovy
@@ -17,7 +17,7 @@ class Package extends AbstractStage {
 
    Package(script, configuration, lvVersion) {
       super(script, 'Package', configuration, lvVersion)
-      this.strategy = new DefaultPackageStrategy()
+      this.strategy = new DefaultPackageStrategy(lvVersion)
    }
 
    void executeStage() {

--- a/src/ni/vsbuild/stages/Package.groovy
+++ b/src/ni/vsbuild/stages/Package.groovy
@@ -16,8 +16,7 @@ class Package extends AbstractStage {
    }
 
    Package(script, configuration, lvVersion) {
-      super(script, 'Package', configuration, lvVersion)
-      this.strategy = new DefaultPackageStrategy(lvVersion)
+      this(script, configuration, lvVersion, new DefaultPackageStrategy(lvVersion))
    }
 
    void executeStage() {

--- a/src/ni/vsbuild/stages/Package.groovy
+++ b/src/ni/vsbuild/stages/Package.groovy
@@ -44,7 +44,7 @@ class Package extends AbstractStage {
 
       this.@packages = []
       for (def packageInfo : packageInfoCollection) {
-         Buildable pkg = PackageFactory.createPackage(script, packageInfo, lvVersion)
+         Buildable pkg = PackageFactory.createPackage(script, packageInfo, lvVersion, strategy)
          this.@packages.add(pkg)
       }
    }

--- a/src/ni/vsbuild/stages/Package.groovy
+++ b/src/ni/vsbuild/stages/Package.groovy
@@ -2,13 +2,22 @@ package ni.vsbuild.stages
 
 import ni.vsbuild.packages.Buildable
 import ni.vsbuild.packages.PackageFactory
+import ni.vsbuild.packages.PackageStrategy
+import ni.vsbuild.packages.DefaultPackageStrategy
 
 class Package extends AbstractStage {
 
    private def packages
+   private PackageStrategy strategy
+
+   Package(script, configuration, lvVersion, strategy) {
+      super(script, 'Package', configuration, lvVersion)
+      this.strategy = strategy
+   }
 
    Package(script, configuration, lvVersion) {
       super(script, 'Package', configuration, lvVersion)
+      this.strategy = new DefaultPackageStrategy()
    }
 
    void executeStage() {
@@ -26,7 +35,22 @@ class Package extends AbstractStage {
       return this.@packages
    }
 
+   boolean stageRequired() {
+      def packageInfoCollection = getPackageInfoCollection()
+      return !packageInfoCollection.isEmpty()
+   }
+
    private void createPackages() {
+      def packageInfoCollection = getPackageInfoCollection()
+
+      this.@packages = []
+      for (def packageInfo : packageInfoCollection) {
+         Buildable pkg = PackageFactory.createPackage(script, packageInfo, lvVersion)
+         this.@packages.add(pkg)
+      }
+   }
+
+   private def getPackageInfoCollection() {
       def packageInfoCollection = []
       // Developers can specify a single package [Package] or a collection of packages [[Package]].
       // Test the package information parameter and iterate as needed.
@@ -37,10 +61,7 @@ class Package extends AbstractStage {
          packageInfoCollection.add(configuration.packageInfo)
       }
 
-      this.@packages = []
-      for (def packageInfo : packageInfoCollection) {
-         Buildable pkg = PackageFactory.createPackage(script, packageInfo, lvVersion)
-         this.@packages.add(pkg)
-      }
+      packageInfoCollection = strategy.filterPackageCollection(packageInfoCollection)
+      return packageInfoCollection
    }
 }

--- a/vars/copyFiles.groovy
+++ b/vars/copyFiles.groovy
@@ -22,7 +22,10 @@ def call(sourceDirectory, destinationDirectory, options=[:]) {
       copyCommand = "$copyCommand $filesToCopy"
    }
    else {
-      commandSwitches = "$commandSwitches /mir"
+      // The /xx command enables mirroring while not removing existing files.
+      // This is what enables merging directories and allows creating post-archive
+      // steps.
+      commandSwitches = "$commandSwitches /xx /mir"
    }
 
    // robocopy uses multiple return codes for success


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-custom-device-build-tools/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Parses `build.toml` to determine if some packages should be built after both the 32- and 64-bit builds of a specific LabVIEW version have completed. If both bitnesses are required in the package, that package is built after each version build has completed and archived its artifacts.

**Note**: There will also need to be updates to the `Toml Help.md` file, but I will file an issue and address that once we have Scan Engine building.

### Why should this Pull Request be merged?

The Scan Engine and EtherCAT custom device needs this capability to build packages for VeriStand 2021. Because VeriStand 2021 will build against LabVIEW RT 64-bit, we need the custom devices to build in 64-bit LabVIEW. But, some drivers are lacking 64-bit support, so we build the configuration and engine in 64-bit, but build things requiring other driver support in 32-bit LabVIEW. These build outputs need to be packaged together.

### What testing has been done?

[PR build](https://nijenkins.amer.corp.natinst.com/view/Veristand/view/GitHub/job/NI/job/niveristand-scan-engine-ethercat-custom-device/view/change-requests/job/PR-191/66/) of Scan Engine using these build changes. The corresponding changes to Scan Engine's `build.toml` will come in a separate PR.
