### PR TITLE
Make diff timeout configurable

### DIFF
--- a/vars/diffPipeline.groovy
+++ b/vars/diffPipeline.groovy
@@ -10,7 +10,10 @@ import ni.vsbuild.LabviewBuildVersion
 
 //This script further assumes that Jenkins is configured (via the Pipeline Shared Libraries plugin) to implicitly include https://github.com/ni/niveristand-custom-device-build-tools
 
-def call(String lvVersion) {
+// The default timeout for diffing is 60 minutes. This is normally sufficient to render all VI diffs.
+// For large diffs, this timeout can be overridden in the Jenkinsfile, either by modifying the Jenkinsfile
+// in the repo or by setting the value when running a Jenkins replay.
+def call(String lvVersion, int diffTimeout = 60) {
    // Skip diffing for build which aren't pull-requests.
    // Only pull-requests will have the change ID set.
    if (!env.CHANGE_ID) {
@@ -37,7 +40,7 @@ def call(String lvVersion) {
       // If this change is a pull request, diff vis.
       stage('Diff VIs') {
          try {
-            timeout(time: 60, unit: 'MINUTES') {
+            timeout(time: diffTimeout, unit: 'MINUTES') {
                lvDiff(lvVersion, env.DIFFING_PIC_REPO, env.GITHUB_DIFF_TOKEN)
                echo 'Diff Succeeded!'
             }
@@ -65,7 +68,7 @@ def call(String lvVersion) {
    }
 }
 
-def call(HashMap<Integer, List<String>> lvVersions) {
+def call(HashMap<Integer, List<String>> lvVersions, int diffTimeout = 60) {
    // The diff script currently expects a 32-bit LabVIEW version.
    // Get the first 32-bit build version to use for the diff
    // by looking up the list of versions in the version map using the
@@ -73,5 +76,5 @@ def call(HashMap<Integer, List<String>> lvVersions) {
    // Ultimately, we may need to figure out a way to diff in either
    // bitness, but for now, we will keep it the same.
    def firstVersionEntry = lvVersions[32][0]
-   call(firstVersionEntry)
+   call(firstVersionEntry, diffTimeout)
 }


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-custom-device-build-tools/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Enables a calling Jenkinsfile to configure the timeout for running the LabVIEW diff.

### Why should this Pull Request be merged?

Some diffs take longer than the default 60 minutes to complete. This change allows the user to configure a timeout such that the diff will finish.

Note: I didn't just increase the default value because, in many cases, a diff that takes longer than an hour begins to become too complex to be useful as just a visual diff in github. In those cases, I don't want to wait longer than the default time before the diff step ends.

### What testing has been done?

Ran a replay of a PR build with the new file and a timeout of 120 minutes set. The build log file indicates the timeout will be "2 hr 0 min".
