### PR TITLE
Skip building if version is too old

### DIFF
--- a/docs/Toml Help.md
+++ b/docs/Toml Help.md
@@ -131,6 +131,7 @@ Key | Description | Required
 `build_spec` | name of the specification to be built | **YES**
 `dependency_target` | path prepended to a dependency's `libraries` key to fetch the correct version of a dependency | **NO**
 `bitness` | limit this step to build only for the provided bitness, either 32 or 64 | **NO**
+`minimum_version` | only run this step if the current version is at least the version specified | **NO**
 `output_dir` | path prepended to a dependency's `libraries` key | **NO** (**_deprecated_**)
 `output_libraries` | array of libraries to be copied to the `output_dir` | **NO** (**_deprecated_**)
 
@@ -169,6 +170,17 @@ build_spec = 'Engine Release'
 dependency_target = 'linux64' # get dependencies from linux64 directory
 ```
 
+Execute a build spec, but only if the current LabVIEW version is the same or newer than LabVIEW 2020.
+```
+[[build.steps]]
+name = 'Configuration Library'
+type = 'lvBuildSpec'
+project = '{first}' # uses the value 'src\first.lvproj' from the example in the Projects section of this document
+target = 'My Computer'
+build_spec = 'Configuration Release'
+minimum_version = '2020'
+```
+
 (**_Deprecated_**) Execute a build spec and output the specified libraries to a specific sub-directory. Builds spec My Library and copies output.llb to a pharlap directory instead of leaving it where it was built.
 ```
 [[build.steps]]
@@ -196,6 +208,7 @@ Key | Description | Required
 `dependency_target` | path prepended to a dependency's `libraries` key to fetch the correct version of a dependency | **NO**
 `bitness` | limit this step to build only for the provided bitness, either 32 or 64 | **NO**
 `bitness_versions` | list of LabVIEW versions where the `bitness` key applies | **NO**
+`minimum_version` | only run this step if the current version is at least the version specified | **NO**
 
 
 ###### Example
@@ -251,6 +264,7 @@ Key | Description | Required
 -|-|-
 `project` | reference to the project table in the projects section of `build.toml`  | **YES**
 `bitness` | limit this step to build only for the provided bitness, either 32 or 64 | **NO**
+`minimum_version` | only run this step if the current version is at least the version specified | **NO**
 
 ###### Example
 ```
@@ -273,6 +287,7 @@ Key | Description | Required
 `condition` | expression to determine which value is chosen for `symbol | **YES**
 `true_value` | desired value of `symbol` when `condition` evaluates to TRUE | **YES**
 `false_value` | desired value of `symbol` when `condition` evaluates to FALSE | **YES**
+`minimum_version` | only run this step if the current version is at least the version specified | **NO**
 
 ###### Example
 ```

--- a/src/ni/vsbuild/steps/LvBuildStep.groovy
+++ b/src/ni/vsbuild/steps/LvBuildStep.groovy
@@ -21,6 +21,10 @@ abstract class LvBuildStep extends LvProjectStep {
          return
       }
 
+      if(!atLeastMinimumVersion()) {
+         return
+      }
+
       copyDependencies(configuration)
 
       def resolvedProject = resolveProject(configuration)

--- a/src/ni/vsbuild/steps/LvStep.groovy
+++ b/src/ni/vsbuild/steps/LvStep.groovy
@@ -7,12 +7,14 @@ abstract class LvStep extends AbstractStep {
    def lvVersion
    def bitness
    def bitnessVersions
+   def minimumVersion
 
    LvStep(script, mapStep, lvVersion) {
       super(script, mapStep)
       this.lvVersion = lvVersion
       this.bitness = mapStep.get('bitness')
       this.bitnessVersions = mapStep.get('bitness_versions')
+      this.minimumVersion = mapStep.get('minimum_version')
    }
 
    // Return true if the current build architecture matches
@@ -37,5 +39,9 @@ abstract class LvStep extends AbstractStep {
       //If no version-specific entry or the current version is found in the list
       //of specific versions, check the bitness of the current version.
       return lvVersion.architecture == Architecture.bitnessToArchitecture(bitness as Integer)
+   }
+
+   public boolean atLeastMiniumVersion() {
+      return lvVersion.lvRuntimeVersion >= minimumVersion
    }
 }

--- a/src/ni/vsbuild/steps/LvStep.groovy
+++ b/src/ni/vsbuild/steps/LvStep.groovy
@@ -41,7 +41,7 @@ abstract class LvStep extends AbstractStep {
       return lvVersion.architecture == Architecture.bitnessToArchitecture(bitness as Integer)
    }
 
-   public boolean atLeastMiniumVersion() {
+   public boolean atLeastMinimumVersion() {
       return lvVersion.lvRuntimeVersion >= minimumVersion
    }
 }


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-custom-device-build-tools/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Adds `minimum_version` property to `build.toml` to prevent building if a project uses unsupported features from an older version of LabVIEW.

### Why should this Pull Request be merged?

The [RDMA feature](https://github.com/ni/niveristand-data-sharing-framework-custom-device-plugins/pull/22) for Data Sharing Framework uses the NI-RDMA driver, which only supports LabVIEW 2020 and newer. The rest of DSF and its plugins support LabVIEW 2019. We don't want to drop 2019, but still need to build the RDMA plugin.

### What testing has been done?

Ran a [test build](http://nijenkins.amer.corp.natinst.com:8090/view/Veristand/view/GitHub/job/NI/job/niveristand-custom-device-message-library/job/dev%252Fmin_version_test/5/) of the messaging custom device and verified 2019 was skipped with minimum version set to '2020'.
