### PR TITLE
Allow package substitution of major version

### DIFF
--- a/src/ni/vsbuild/packages/AbstractPackage.groovy
+++ b/src/ni/vsbuild/packages/AbstractPackage.groovy
@@ -41,13 +41,8 @@ abstract class AbstractPackage implements Buildable {
          return INVALID_VERSION
       }
 
-      def baseVersion = script.env.BRANCH_NAME.split("[-/]")[1]
-      def versionPartCount = baseVersion.tokenize(".").size()
-
-      def versionPartsToDisplay = 3
-      for(versionPartCount; versionPartCount < versionPartsToDisplay; versionPartCount++) {
-         baseVersion = "${baseVersion}.0"
-      }
+      def branchVersion = script.env.BRANCH_NAME.split("[-/]")[1]
+      def baseVersion = buildVersionString(branchVersion)
 
       return baseVersion
    }
@@ -57,5 +52,24 @@ abstract class AbstractPackage implements Buildable {
       def fullVersion = "${baseVersion}.${script.currentBuild.number}"
 
       return fullVersion
+   }
+
+   protected def getMajorVersion() {
+      def baseVersion = getBaseVersion()
+      def majorVersion = buildVersionString(baseVersion.tokenize(".")[0])
+
+      return majorVersion
+   }
+
+   private def buildVersionString(def startingVersion) {
+      def finalVersion = startingVersion
+      def versionPartCount = startingVersion.tokenize(".").size()
+
+      def versionPartsToDisplay = 3
+      for(versionPartCount; versionPartCount < versionPartsToDisplay; versionPartCount++) {
+         finalVersion = "${finalVersion}.0"
+      }
+
+      return finalVersion
    }
 }

--- a/src/ni/vsbuild/packages/Nipkg.groovy
+++ b/src/ni/vsbuild/packages/Nipkg.groovy
@@ -112,8 +112,9 @@ class Nipkg extends AbstractPackage {
    private String updateVersionVariables(text) {
       def baseVersion = getBaseVersion()
       def fullVersion = getFullVersion()
+      def majorVersion = getMajorVersion()
 
-      def additionalReplacements = ['nipkg_version': fullVersion, 'display_version': baseVersion]
+      def additionalReplacements = ['nipkg_version': fullVersion, 'display_version': baseVersion, 'major_version': majorVersion]
       return StringSubstitution.replaceStrings(text, lvVersion, additionalReplacements)
    }
 


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-custom-device-build-tools/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Enables a user to specify `major_version` in a `control` file to substitute a dependency version.

### Why should this Pull Request be merged?

The DSF plugins need a new release to support RDMA, but there is no reason to create a new release of the DSF custom device because there are zero changes since the last release.

### What testing has been done?

Will use this branch to build [DSF Plugin PR 24](https://github.com/ni/niveristand-data-sharing-framework-custom-device-plugins/pull/24) and verify the `nipkg` that is created will correctly install if DSF custom device 21.0 is installed.
