### PR TITLE
Just return number for major version

### DIFF
--- a/src/ni/vsbuild/packages/AbstractPackage.groovy
+++ b/src/ni/vsbuild/packages/AbstractPackage.groovy
@@ -56,7 +56,7 @@ abstract class AbstractPackage implements Buildable {
 
    protected def getMajorVersion() {
       def baseVersion = getBaseVersion()
-      def majorVersion = buildVersionString(baseVersion.tokenize(".")[0])
+      def majorVersion = baseVersion.tokenize(".")[0]
 
       return majorVersion
    }


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-custom-device-build-tools/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Returns only the number for the major version instead of appending `.0.0`.

### Why should this Pull Request be merged?

It's possible we would want something beyond the `.0.0` version at some point, so just let the control file determine what is to be used after the major version.

### What testing has been done?

N/A
