### PR TITLE
Choose x64 architecture for multi-bitness packages

### DIFF
--- a/src/ni/vsbuild/Pipeline.groovy
+++ b/src/ni/vsbuild/Pipeline.groovy
@@ -326,7 +326,12 @@ class Pipeline implements Serializable {
             continue
          }
 
-         postArchiveStages[key] = stage
+         // Only add the x64 stage. Post-archive should not be used
+         // if multiple bitness is not required and x64 is the
+         // architecture to be used for building packages in that case.
+         if (stage.lvVersion.architecture == Architecture.x64) {
+            postArchiveStages[key] = stage
+         }
       }
    }
 

--- a/src/ni/vsbuild/Pipeline.groovy
+++ b/src/ni/vsbuild/Pipeline.groovy
@@ -318,18 +318,14 @@ class Pipeline implements Serializable {
       for (def stage : stages) {
          def key = [stage.getClass(), stage.lvVersion.lvRuntimeVersion]
 
-         // Only add one post-archive stage per stage type and LV year version.
-         // Post-archive should only be used for stages requiring both 32- and
-         // 64-bit versions of the same LV year version. If a stage already
-         // exists for that combination, don't add another.
-         if (postArchiveStages[key]) {
-            continue
-         }
-
          // Only add the x64 stage. Post-archive should not be used
          // if multiple bitness is not required and x64 is the
          // architecture to be used for building packages in that case.
          if (stage.lvVersion.architecture == Architecture.x64) {
+            if (postArchiveStages[key]) {
+               script.failBuild("Attempted to add multiple post-archive stages for $key.")
+            }
+
             postArchiveStages[key] = stage
          }
       }


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-custom-device-build-tools/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Selects the x64 architecture for running post-archive stages in the build pipeline. Post-archive should only be used for building packages containing both 32- and 64-bit binaries. In this case, always choose the 64-bit architecture for determining install paths.

### Why should this Pull Request be merged?

Addresses AB#2092858 where the Scan Engine custom device is not correctly installing the scripting API, examples, or error files for VeriStand LabVIEW 2021.

### What testing has been done?

Ran a replay build of a Scan Engine custom device PR build and verified the `nipkg` files will actually install and files are placed in the correct locations.

![image](https://user-images.githubusercontent.com/29306186/183140742-4f187948-8734-4add-9a4c-e2c6d318eefa.png)
![image](https://user-images.githubusercontent.com/29306186/183140877-c2a69b3f-2478-44e9-bd5f-5cf4fd02497c.png)
![image](https://user-images.githubusercontent.com/29306186/183141104-0637630d-352d-4b70-ae42-680f069d32db.png)

