### PR TITLE
Retry workspace deletion

### DIFF
--- a/src/ni/vsbuild/Pipeline.groovy
+++ b/src/ni/vsbuild/Pipeline.groovy
@@ -179,7 +179,7 @@ class Pipeline implements Serializable {
       def config
       script.node(pipelineInformation.nodeLabel) {
          script.stage('Checkout_readBuildInformation') {
-            script.deleteDir()
+            script.cleanWorkspace()
             script.echo 'Attempting to get source from repo.'
             script.timeout(time: checkoutTimeoutInMinutes, unit: 'MINUTES'){
                manifest['scm'] = script.checkout(script.scm)
@@ -280,7 +280,7 @@ class Pipeline implements Serializable {
       def manifest = script.readJSON text: '{}'
 
       script.stage("Checkout_$lvVersion") {
-         script.deleteDir()
+         script.cleanWorkspace()
          script.echo 'Attempting to get source from repo.'
          script.timeout(time: checkoutTimeoutInMinutes, unit: 'MINUTES'){
             manifest['scm'] = script.checkout(script.scm)

--- a/vars/cleanWorkspace.groovy
+++ b/vars/cleanWorkspace.groovy
@@ -4,7 +4,7 @@ def call(retryAttempts = 3) {
    retry(retryAttempts) {
       echo 'Attempting to delete workspace'
       if (!firstAttempt) {
-         sleep time: 5, unit: SECONDS
+         sleep time: 5, unit: 'SECONDS'
       } else {
          firstAttempt = false
       }

--- a/vars/cleanWorkspace.groovy
+++ b/vars/cleanWorkspace.groovy
@@ -1,0 +1,14 @@
+def call(retryAttempts = 3) {
+   def firstAttempt = true
+
+   script.retry(retryAttempts) {
+      script.echo 'Attempting to delete workspace'
+      if (!firstAttempt) {
+         script.sleep time: 5 unit: SECONDS
+      } else {
+         firstAttempt = false
+      }
+
+      script.deleteDir()
+   }
+}

--- a/vars/cleanWorkspace.groovy
+++ b/vars/cleanWorkspace.groovy
@@ -1,14 +1,14 @@
 def call(retryAttempts = 3) {
    def firstAttempt = true
 
-   script.retry(retryAttempts) {
-      script.echo 'Attempting to delete workspace'
+   retry(retryAttempts) {
+      echo 'Attempting to delete workspace'
       if (!firstAttempt) {
-         script.sleep time: 5, unit: SECONDS
+         sleep time: 5, unit: SECONDS
       } else {
          firstAttempt = false
       }
 
-      script.deleteDir()
+      deleteDir()
    }
 }

--- a/vars/cleanWorkspace.groovy
+++ b/vars/cleanWorkspace.groovy
@@ -4,7 +4,7 @@ def call(retryAttempts = 3) {
    script.retry(retryAttempts) {
       script.echo 'Attempting to delete workspace'
       if (!firstAttempt) {
-         script.sleep time: 5 unit: SECONDS
+         script.sleep time: 5, unit: SECONDS
       } else {
          firstAttempt = false
       }

--- a/vars/diffPipeline.groovy
+++ b/vars/diffPipeline.groovy
@@ -25,7 +25,7 @@ def call(String lvVersion, int diffTimeout = 60) {
    node(lvVersion) {
       echo 'Starting build...'
       stage('Pre-Clean') {
-         deleteDir()
+         cleanWorkspace()
       }
       stage('SCM_Checkout') {
          echo 'Attempting to get source from repo...'
@@ -59,7 +59,7 @@ def call(String lvVersion, int diffTimeout = 60) {
       }
       stage('Cleanup') {
          try {
-            deleteDir()
+            cleanWorkspace()
          }
          catch (CompositeIOException | FileSystemException e) {
                echo "Directory cleanup failed"


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-custom-device-build-tools/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Attempts to retry calling `deleteDir()` when the first call fails.

### Why should this Pull Request be merged?

The build machines have been more frequently hitting an issue where files are not released by LabVIEW in time to successfully call `deleteDir()` to clear the workspace. This change adds a retry with a 5 second sleep between attempts to give the OS more time to release the files.

Fixes #128 

### What testing has been done?

Ran PR build and verified files are correctly deleted.
![image](https://user-images.githubusercontent.com/29306186/185145312-004ee109-1357-4f05-b9db-e7384e3e2789.png)

Jenkins [retry](https://www.jenkins.io/doc/pipeline/steps/workflow-basic-steps/#retry-retry-the-body-up-to-n-times)
