### PR TITLE
Add new variable substitutions for quarterly release versions

### DIFF
--- a/src/ni/vsbuild/packages/AbstractPackage.groovy
+++ b/src/ni/vsbuild/packages/AbstractPackage.groovy
@@ -3,7 +3,7 @@ package ni.vsbuild.packages
 abstract class AbstractPackage implements Buildable {
 
    static final String INSTALLER_DIRECTORY = "installer"
-   static final String INVALID_VERSION = "0.0.0"
+   static final String INVALID_VERSION = "23.0.0"
 
    def script
    def type
@@ -35,6 +35,17 @@ abstract class AbstractPackage implements Buildable {
       return []
    }
 
+   protected def getQuarterlyDisplayVersion() {
+      // Rather than try to finalize the versioning policy now,
+      // punt and just handle the immediate case.
+      def baseVersion = getBaseVersion()
+      if (baseVersion == "23.0.0") {
+         return "2023 Q1"
+      }
+
+      return baseVersion
+   }
+
    protected def getBaseVersion() {
       if (script.env.CHANGE_ID) {
          // Assign an invalid version to pull requests
@@ -59,6 +70,20 @@ abstract class AbstractPackage implements Buildable {
       def majorVersion = baseVersion.tokenize(".")[0]
 
       return majorVersion
+   }
+
+   protected def getMinorVersion() {
+      def baseVersion = getBaseVersion()
+      def minorVersion = baseVersion.tokenize(".")[1]
+
+      return minorVersion
+   }
+
+   protected def getUpdateVersion() {
+      def baseVersion = getBaseVersion()
+      def updateVersion = baseVersion.tokenize(".")[2]
+
+      return updateVersion
    }
 
    protected def buildVersionString(def startingVersion) {

--- a/src/ni/vsbuild/packages/AbstractPackage.groovy
+++ b/src/ni/vsbuild/packages/AbstractPackage.groovy
@@ -3,7 +3,7 @@ package ni.vsbuild.packages
 abstract class AbstractPackage implements Buildable {
 
    static final String INSTALLER_DIRECTORY = "installer"
-   static final String INVALID_VERSION = "23.0.0"
+   static final String INVALID_VERSION = "0.0.0"
 
    def script
    def type

--- a/src/ni/vsbuild/packages/Nipkg.groovy
+++ b/src/ni/vsbuild/packages/Nipkg.groovy
@@ -113,8 +113,20 @@ class Nipkg extends AbstractPackage {
       def baseVersion = getBaseVersion()
       def fullVersion = getFullVersion()
       def majorVersion = getMajorVersion()
+      def minorVersion = getMinorVersion()
+      def updateVersion = getUpdateVersion()
 
-      def additionalReplacements = ['nipkg_version': fullVersion, 'display_version': baseVersion, 'major_version': majorVersion]
+      def additionalReplacements = [
+         'major_version': majorVersion,
+         'minor_version': minorVersion,
+         'update_version': updateVersion,
+         'major_minor_version': "$majorVersion.$minorVersion",
+         'major_minor_update_version': "$majorVersion.$minorVersion.$updateVersion",
+         'major_minor_update_build_version': fullVersion,
+         'nipkg_version': fullVersion,
+         'display_version': baseVersion,
+         'quarterly_display_version': getQuarterlyDisplayVersion(),
+      ]
       return StringSubstitution.replaceStrings(text, lvVersion, additionalReplacements)
    }
 


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-custom-device-build-tools/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Introduce new variable substitutions for control files, to enable packages to use the new quarterly release versioning scheme.

### Why should this Pull Request be merged?

The custom device feed already uses this display version; this is the logical next step.

### What testing has been done?

Replayed builds for with a control file using the new variables.

