### PR TITLE
Use 64-bit LabVIEW for running diff

### DIFF
--- a/resources/labview_diff.py
+++ b/resources/labview_diff.py
@@ -60,7 +60,7 @@ def labview_path_from_year(year):
         return os.environ[env_key]
 
     return r"{0}\National Instruments\LabVIEW {1}\LabVIEW.exe".format(
-        os.environ["ProgramFiles(x86)"], year
+        os.environ["ProgramFiles"], year
     )
 
 

--- a/vars/diffPipeline.groovy
+++ b/vars/diffPipeline.groovy
@@ -69,12 +69,10 @@ def call(String lvVersion, int diffTimeout = 60) {
 }
 
 def call(HashMap<Integer, List<String>> lvVersions, int diffTimeout = 60) {
-   // The diff script currently expects a 32-bit LabVIEW version.
-   // Get the first 32-bit build version to use for the diff
+   // The diff script expects a 64-bit LabVIEW version.
+   // Get the first 64-bit build version to use for the diff
    // by looking up the list of versions in the version map using the
-   // 32-bit key and then indexing the first item in the list.
-   // Ultimately, we may need to figure out a way to diff in either
-   // bitness, but for now, we will keep it the same.
+   // 64-bit key and then indexing the first item in the list.
    def firstVersionEntry = lvVersions[64][0]
    call(firstVersionEntry, diffTimeout)
 }

--- a/vars/diffPipeline.groovy
+++ b/vars/diffPipeline.groovy
@@ -75,6 +75,6 @@ def call(HashMap<Integer, List<String>> lvVersions, int diffTimeout = 60) {
    // 32-bit key and then indexing the first item in the list.
    // Ultimately, we may need to figure out a way to diff in either
    // bitness, but for now, we will keep it the same.
-   def firstVersionEntry = lvVersions[32][0]
+   def firstVersionEntry = lvVersions[64][0]
    call(firstVersionEntry, diffTimeout)
 }


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-custom-device-build-tools/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Uses 64-bit LabVIEW to diff VIs instead of 32-bit.

### Why should this Pull Request be merged?

We now have a custom device that is only supported in VS 2021 and later, which means we are only building with 64-bit LV. We need diffs for that repo. This change should be safe because all custom devices should now be building against at least one version of 64-bit LV.

### What testing has been done?

Ran a build using only a 64-bit LV and verified diffs were created and posted to GitHub.
https://github.com/ni/niveristand-adas-toolkit-custom-device/pull/4
