### PR TITLE
Add support for LabVIEW-version agnostic dependencies

### DIFF
--- a/src/ni/vsbuild/StringSubstitution.groovy
+++ b/src/ni/vsbuild/StringSubstitution.groovy
@@ -12,7 +12,22 @@ class StringSubstitution implements Serializable {
             "pkg_x86_bitness_suffix": architecture == Architecture.x86 ? "-x86" : "",
             "nipaths_64_bitness_suffix": architecture == Architecture.x64 ? "64" : "",
       ]
-      replacements << getLegacySubstitutionStrings()
+
+      switch (year) {
+         case '2019':
+            replacements.put("labview_support_package_suffix", "labview-2019-support{pkg_x86_bitness_suffix}");
+            break;
+         case '2020':
+            replacements.put("labview_support_package_suffix", "labview-2020-support{pkg_x86_bitness_suffix}");
+            break;
+         case '2021':
+            replacements.put("labview_support_package_suffix", "labview-2021-support{pkg_x86_bitness_suffix}");
+            break;
+         default:
+            replacements.put("labview_support_package_suffix", "labview-support");
+            break;
+      }
+
       replacements << additionalReplacements
 
       // Potentially run multiple times to allow nested replacement strings,
@@ -30,42 +45,5 @@ class StringSubstitution implements Serializable {
       }
 
       return updatedText
-   }
-
-   // TODO: These are deprecated as we target VeriStand 2019 as a minimum version,
-   // but we need to remove their usage in custom devices before removing the definitions.
-   private static Map<String, String> getLegacySubstitutionStrings()
-   {
-      def substitutionStrings = [
-            "ni-veristand-2017": "89bad39c-da8d-4c78-ba1a-f5de0dafdc00",
-            "ni-veristand-2018": "d8f1d4e0-3466-42b0-92da-bdad96c42600",
-            // We cannot simply map to the upgrade code defined by LabVIEW 2017, because
-            // LabVIEW 2017 SP1 defines a different one. Instead we need to OR them, so that the
-            // presence of either is sufficient. This makes listing the dependency in a control file
-            // slightly awkward since you won't list a version; we prefix the variable with AUTOVERSION_
-            // to hopefully make this slightly clearer.
-            "AUTOVERSION_ni-labview-2017-x86": "aa4b25c0-a1f6-472e-8f76-32e406b7e44d (>=17.0.0) | 7a80ea72-c69d-4740-afbf-326544b9462c (>=17.1.0)",
-      ]
-
-      // Update the upper bound with each additional year release that uses the same package name format
-      // Once we no longer need the legacy codes (i.e. the minimum supported VeriStand version is 2019) we
-      // can deprecate this function, and just use the package names and versions directly.
-      def upperYearBound = 21
-      for (int year = 19; year <= upperYearBound; year++)
-      {
-         substitutionStrings.put(
-               "ni-veristand-20${year}".toString(),
-               "ni-veristand-20${year}".toString(),
-         )
-      }
-      for (int year = 18; year <= upperYearBound; year++)
-      {
-         substitutionStrings.put(
-               "AUTOVERSION_ni-labview-20${year}-x86".toString(),
-               "ni-labview-20${year}-x86 (>=${year}.0.0)".toString(),
-         )
-      }
-
-      return substitutionStrings
    }
 }


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-custom-device-build-tools/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Add support for LabVIEW-version agnostic dependencies.

Also remove support for VeriStand 2017 and 2018.

### Why should this Pull Request be merged?

This is needed to support drivers like NI-SWITCH who now provide their LabVIEW support in a version independent way.

### What testing has been done?

Replayed a Routing and Faulting build with the changes and inspected the generated packages.
