### PR TITLE
Fix PR branch name, and add error checking and writing to catch user mistakes

### DIFF
--- a/azure-templates/stages.yml
+++ b/azure-templates/stages.yml
@@ -30,15 +30,15 @@ parameters:
 
 # Note: If custom build steps are needed for a particular custom device, copy this entire template into the azure-pipeline and add steps before/after as needed
 stages:
-  - stage: build  
+  - stage: Build
     pool:
-      name: custom-device-temp # TEMPORARY, eventually use an official build pool of custom device agents
+      name: custom-device-temp # TEMPORARY, eventually use an official build pool of custom device agents!!
       demands:
         - agent.os -equals Windows_NT
     jobs:
       - ${{ each lvVersionToBuild in parameters.lvVersionsToBuild }}:
         - job: Job${{ lvVersionToBuild.version }}_${{ lvVersionToBuild.bitness }}
-          displayName: Build for LabVIEW ${{ lvVersionToBuild.version }}
+          displayName: LabVIEW ${{ lvVersionToBuild.version }}
           steps:
             - template: steps-pre-build.yml@niveristand-custom-device-build-tools # Configure variables, check out repos, Clear cache
               parameters:
@@ -60,7 +60,7 @@ stages:
                 pack:     ${{ parameters.pack }}
         # if all jobs have passed, place .finished file in top level archive location TEMPORARY - linked to imitation-cd instead of build-tools
       - job: Finalize
-        displayName: Confirm All Builds Passed
+        displayName: Final Validation
         dependsOn:
           - ${{ each lvVersionToBuild in parameters.lvVersionsToBuild }}:
             - Job${{ lvVersionToBuild.version }}_${{ lvVersionToBuild.bitness }}
@@ -68,7 +68,19 @@ stages:
         steps:
           # archivePath defined in pre-job-steps.yml
         - powershell: |
+            If ('$(Build.Reason)' -eq 'PullRequest')
+            {
+              Write-Output "Setting variables for Pull Requests..."
+              $sourceBranch = "$(System.PullRequest.SourceBranch)" -replace 'dev/', ''
+            } 
+            Else
+            {
+              Write-Output "Setting variables for general builds..."
+              $sourceBranch = "$(Build.SourceBranchName)"
+            }
+            Write-Output "Using $sourceBranch in final validation path..."
+            Write-Output "All previous jobs complete.  Storing .finished file..."
             New-Item `
-              -Path "${{ parameters.archiveLocation }}\NI\export\$(Build.SourceBranchName)\$(Build.BuildNumber)" `
+              -Path "${{ parameters.archiveLocation }}\NI\export\$sourceBranch\$(Build.BuildNumber)" `
               -Name ".finished" `
               -ItemType "File"

--- a/azure-templates/steps-build.yml
+++ b/azure-templates/steps-build.yml
@@ -9,7 +9,7 @@ parameters:
   # buildTools, lvCLICall
 
 steps:
-  - ${{ each dependency in parameters.dependencies }}: # TEMPORARY - default branchName is 'azure-pipelines' until things are actually committed to main on dependencies
+  - ${{ each dependency in parameters.dependencies }}:
     - ${{ if ne( dependency.file, '' )}}:
       - task: PowerShell@2
         displayName: Copy dependency ${{ dependency.file }} to ${{ dependency.destination }}

--- a/azure-templates/steps-build.yml
+++ b/azure-templates/steps-build.yml
@@ -15,25 +15,27 @@ steps:
         displayName: Copy dependency ${{ dependency.file }} to ${{ dependency.destination }}
         inputs:
           targetType: 'inline'
+          failOnStdErr: true
           script: |
             Write-Output "Configuring target directory environment..."
             If ('${{ parameters.buildStep.target }}' -eq 'My Computer')
             {
               $dependencyTargetDirectory = "Windows"
             }
-            If ('${{ parameters.buildStep.target }}' -eq 'Linux x64')
+            Elseif ('${{ parameters.buildStep.target }}' -eq 'Linux x64')
             {
               $dependencyTargetDirectory = "Linux_x64"
             }
+            Write-Output "Setting dependency environment to $dependencyTargetDirectory"
             `
             $branchName = 'main'
-            If ('$(Build.SourceBranchName)' -ne $branchName )
+            If ('$(sourceBranch)' -ne $branchName )
             {
-              Write-Output "Checking for builds of $(Build.SourceBranchName) branch..."
-              If (Test-Path -Path "${{ dependency.source }}\NI\export\$(Build.SourceBranchName)\*\$(lvVersion)\$(architecture)") 
+              Write-Output "Checking for builds of $(sourceBranch) branch..."
+              If (Test-Path -Path "${{ dependency.source }}\NI\export\$(sourceBranch)\*\$(lvVersion)\$(architecture)") 
               {
-                Write-Output "branch was found, using $(Build.SourceBranchName) instead of $branchName..."
-                $branchName = '$(Build.SourceBranchName)'
+                Write-Output "branch was found, using $(sourceBranch) instead of $branchName..."
+                $branchName = '$(sourceBranch)'
               }
               Else
               {
@@ -59,6 +61,10 @@ steps:
                 Break
               }
             }
+            If (-not $dependencyFilePath)
+            {
+              Write-Error "no successful build of dependency ${{ dependency.file }} was found at ${{ dependency.source }}."
+            }
             `
             Write-Output "Copying dependency ${{ dependency.file }}..."
             If (-not(Test-Path -Path '$(customDeviceRepoName)\${{ dependency.destination }}'))
@@ -77,31 +83,37 @@ steps:
     displayName: Prepare to build ${{ parameters.buildStep.buildSpec }} on ${{ parameters.buildStep.target }} in ${{ parameters.buildStep.projectLocation }}
     inputs:
       targetType: 'inline'
+      failOnStdErr: true
       script: |
-        Write-Output "Add LabVIEW config file if needed..."
         If (-not(Test-Path -Path "$(customDeviceRepoName)\${{ parameters.buildStep.projectLocation }}.config"))
         {
+          Write-Output "adding .config file to project..."
           $lvConfigFilePath = '$(customDeviceRepoName)\${{ parameters.buildStep.projectLocation }}.config'
           Copy-Item "$(buildTools)\resources\LabVIEW.exe.config" -Destination $lvConfigFilePath
           (Get-Content -Path $lvConfigFilePath) -replace '2016.0.0.0', '$(lvConfigVersion)' | Set-Content -Path $lvConfigFilePath
         }
         `
-        Write-Output "Set target and buildSpec arguments if needed..."
-        If ('${{ parameters.buildStep.target }}' -eq 'All')
+        If ('${{ parameters.buildStep.buildOperation }}' -eq 'ExecuteAllBuildSpecs')
         {
+          Write-Output "Configuring build operation for all targets and build specs..."
           Write-Host '##vso[task.setvariable variable=targetArgument]'
-        } 
-        Else
-        {
-          Write-Host '##vso[task.setvariable variable=targetArgument]-TargetName "${{ parameters.buildStep.target }}" '
-        }
-        If ('${{ parameters.buildStep.buildSpec }}' -eq 'All')
-        {
           Write-Host '##vso[task.setvariable variable=buildSpecArgument]'
+        } 
+        Elseif ('${{ parameters.buildStep.buildOperation }}' -eq 'ExecuteBuildSpecAllTargets')
+        {
+          Write-Output "Configuring build operation for all targets and single build spec..."
+          Write-Host '##vso[task.setvariable variable=targetArgument]'
+          Write-Host '##vso[task.setvariable variable=buildSpecArgument]-BuildSpecName "${{ parameters.buildStep.buildSpec }}" ' 
+        }
+        Elseif ('${{ parameters.buildStep.buildOperation }}' -eq 'ExecuteBuildSpec')
+        {
+          Write-Output "Configuring build operation for specific target and build spec..."
+          Write-Host '##vso[task.setvariable variable=targetArgument]-TargetName "${{ parameters.buildStep.target }}" '
+          Write-Host '##vso[task.setvariable variable=buildSpecArgument]-BuildSpecName "${{ parameters.buildStep.buildSpec }}" '
         }
         Else
         {
-          Write-Host '##vso[task.setvariable variable=buildSpecArgument]-BuildSpecName "${{ parameters.buildStep.buildSpec }}" '
+          Write-Error "invalid buildStep.buildOperation provided.  Valid options are ExecuteBuildSpec, ExecuteBuildSpecAllTargets, and ExecuteAllBuildSpecs."
         }
 
   - task: CmdLine@2

--- a/azure-templates/steps-pre-build.yml
+++ b/azure-templates/steps-pre-build.yml
@@ -11,14 +11,30 @@ parameters:
     type: string
 
 steps:
+    # Variables that are set in a powershell script cannot be used within the same script 
+    # because the variables are resolved when the script is first loaded, so generate all 
+    # variables at the beginning.
   - task: PowerShell@2
     displayName: Configure Job-wide Variables for LabVIEW ${{ parameters.lvVersionToBuild.version }} ${{ parameters.lvVersionToBuild.bitness }}
     inputs: 
       targetType: 'inline'
+      failOnStdErr: true
       script: |
         Write-Output "Defining repository variables..."
         Write-Host '##vso[task.setvariable variable=buildTools]niveristand-custom-device-build-tools'
-        Write-Host '##vso[task.setvariable variable=archivePath]${{ parameters.archiveLocation }}\NI\export\$(Build.SourceBranchName)\'
+        If ('$(Build.Reason)' -eq 'PullRequest')
+        {
+          Write-Output "Setting variables for Pull Requests..."
+          $sourceBranch = "$(System.PullRequest.SourceBranch)" -replace 'dev/', ''
+        } 
+        Else
+        {
+          Write-Output "Setting variables for general builds..."
+          $sourceBranch = "$(Build.SourceBranchName)"
+        }
+        Write-Output "Using $sourceBranch in archive path..."
+        Write-Host "##vso[task.setvariable variable=sourceBranch]$sourceBranch"
+        Write-Host "##vso[task.setvariable variable=archivePath]${{ parameters.archiveLocation }}\NI\export\$sourceBranch\"
         $customDeviceRepoName = '$(Build.Repository.Name)' -replace '.+\/', ''
         Write-Host "##vso[task.setvariable variable=customDeviceRepoName]$customDeviceRepoName"
         Write-Host "##vso[task.setvariable variable=buildOutputPath]$customDeviceRepoName\${{ parameters.buildOutputLocation }}"
@@ -30,33 +46,46 @@ steps:
         Write-Host '##vso[task.setvariable variable=lvVersion]${{ parameters.lvVersionToBuild.version }}'
         If ('${{ parameters.lvVersionToBuild.bitness }}' -eq '32bit')
         {
+          Write-Output "Setting variables for 32-bit..."
           Write-Host '##vso[task.setvariable variable=lvPath]C:\Program Files (x86)\National Instruments\LabVIEW ${{ parameters.lvVersionToBuild.version }}'
           Write-Host '##vso[task.setvariable variable=architecture]x86'
           Write-Host '##vso[task.setvariable variable=nipkgx86suffix]-x86'
           Write-Host '##vso[task.setvariable variable=nipkgx64suffix]'
         }
-        If ('${{ parameters.lvVersionToBuild.bitness }}' -eq '64bit')
+        Elseif ('${{ parameters.lvVersionToBuild.bitness }}' -eq '64bit')
         {
+          Write-Output "Setting variables for 64-bit..."
           Write-Host '##vso[task.setvariable variable=lvPath]C:\Program Files\National Instruments\LabVIEW ${{ parameters.lvVersionToBuild.version }}'
           Write-Host '##vso[task.setvariable variable=architecture]x64'
           Write-Host '##vso[task.setvariable variable=nipkgx86suffix]'
           Write-Host '##vso[task.setvariable variable=nipkgx64suffix]64'
         }     
+        Else
+        {
+          Write-Error "Invalid Bitness defined in pipeline.  Use either 32bit or 64bit."
+        }
         `
         If ('${{ parameters.lvVersionToBuild.version }}' -eq '2020')
         {
+          Write-Output "Setting variables for LabVIEW 2020..."
           Write-Host '##vso[task.setvariable variable=lvConfigVersion]8.0.0.0'
           Write-Host '##vso[task.setvariable variable=shortLvVersion]20'
         }
-        If ('${{ parameters.lvVersionToBuild.version }}' -eq '2021')
+        Elseif ('${{ parameters.lvVersionToBuild.version }}' -eq '2021')
         {
+          Write-Output "Setting variables for LabVIEW 2021..."
           Write-Host '##vso[task.setvariable variable=lvConfigVersion]9.0.0.0'
           Write-Host '##vso[task.setvariable variable=shortLvVersion]21'
         }
-        If ('${{ parameters.lvVersionToBuild.version }}' -eq '2023')
+        Elseif ('${{ parameters.lvVersionToBuild.version }}' -eq '2023')
         {
+          Write-Output "Setting variables for LabVIEW 2023..."
           Write-Host '##vso[task.setvariable variable=lvConfigVersion]10.0.0.0'
           Write-Host '##vso[task.setvariable variable=shortLvVersion]23'
+        }
+        Else
+        {
+          Write-Error "Invalid LabVIEW version defined in pipeline.  Use either 2020, 2021, or 2023."
         }
 
   - powershell: Write-Host '##vso[task.setvariable variable=lvCLICall]LabVIEWCLI -PortNumber 3363 -LabVIEWPath "$(lvPath)\LabVIEW.exe" -AdditionalOperationDirectory "%cd%\$(buildTools)\lv\operations"'


### PR DESCRIPTION
- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-custom-device-build-tools/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

1. fix "build Build" nomenclature on GitHub build status by adjusting stage/job naming
2. Add conditional logic to use System.PullRequest.SourceBranch instead of Build.SourceBranchName when building for a PR, because PR builds use a different source branch labeled "merge"
3. Changed if statements to be Elseif when relevant
4. Added Write-Error and Write-Output items to catch issues where invalid parameters are provided in the pipeline with explicit error information
5. Rearranged BuildSpec conditional logic to check for specific build operations instead of requiring a specific value in buildStep.target or buildStep.buildSpec for "build all" scenarios

### Why should this Pull Request be merged?

This cleans up a few issues that were identified after first PR+push of the various build pipelines, and it clarifies the behavior in some areas to make it more robust/easier to troubleshoot

### What testing has been done?

Built successfully using the imitation-cd, correct pathing was used: https://github.com/papowerNI/imitation-cd/pull/1
Also checked error cases:
Try invalid build spec: https://dev.azure.com/ni/Users/_build/results?buildId=3769716&view=results
Try invalid bitness: https://dev.azure.com/ni/Users/_build/results?buildId=3769803&view=results
Try invalid LabVIEW version: https://dev.azure.com/ni/Users/_build/results?buildId=3769786&view=results