### PR TITLE
change codegen to work for all build operations, and remove unnecessary pack parameter

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -94,7 +94,6 @@ stages:
       archiveLocation: '\\nirvana\Measurements\VeriStandAddons\prototype\niveristand-custom-device-build-tools'
 
 # Test Building multiple packages with multiple payload maps
-      pack: true
       packages:
         - controlFileName: 'test-build\control-a'
           payloadMaps:

--- a/azure-templates/stages.yml
+++ b/azure-templates/stages.yml
@@ -35,11 +35,6 @@ parameters:
   - name: archiveLocation
     type: string
 
-  # pack (optional)
-  - name: pack
-    type: boolean
-    default: false
-
 # Note: If custom build steps are needed for a particular custom device, copy this entire template into the azure-pipeline and add steps before/after as needed
 stages:
   - stage: Build

--- a/azure-templates/stages.yml
+++ b/azure-templates/stages.yml
@@ -22,6 +22,8 @@ parameters:
   # packages: list of {controlFileName, payloadMaps: list of {payloadLocation, installLocation} }
   - name: packages
     type: object
+    default:
+      - controlFileName: ''
 
   # strings (releaseVersion, quarterlyReleaseVersion, buildOutputLocation, archiveLocation)
   - name: releaseVersion
@@ -69,7 +71,7 @@ stages:
             - template: steps-post-build.yml # nipkg and archive
               parameters:
                 packages: ${{ parameters.packages }}
-                pack:     ${{ parameters.pack }}
+
         # if all jobs have passed, place .finished file in top level archive location TEMPORARY - linked to imitation-cd instead of build-tools
       - job: Finalize
         displayName: Final Validation

--- a/azure-templates/steps-build.yml
+++ b/azure-templates/steps-build.yml
@@ -92,6 +92,13 @@ steps:
               -Destination '$(customDeviceRepoName)\${{ dependency.destination }}\' `
               -Recurse `
               -Force
+    - ${{ if and( ne( dependency.file, '' ), ne( parameters.buildStep.buildOperation, 'ExecuteBuildSpec' ))}}:
+      - task: PowerShell@2
+        displayName: dependency not used because buildOperation not supported for this buildStep
+        inputs:
+          targetType: 'inline'
+          failOnStdErr: true
+          script: Write-Output "only use dependencies for ExecuteBuildSpec build operation.  Other build operations do not support dependencies."
 
   - task: PowerShell@2
     displayName: Prepare to build ${{ parameters.buildStep.buildSpec }} on ${{ parameters.buildStep.target }} in ${{ parameters.buildStep.projectLocation }}

--- a/azure-templates/steps-build.yml
+++ b/azure-templates/steps-build.yml
@@ -145,7 +145,7 @@ steps:
 
 
   - ${{ each codegenVi in parameters.codegenVis }}:
-    - ${{ if and( ne(codegenVi, '' ), eq( parameters.buildStep.buildOperation, 'ExecuteBuildSpec' ))}}:
+    - ${{ if ne(codegenVi, '' )}}:
       - task: CmdLine@2
         displayName: Run codegen step ${{ codegenVi }}
         inputs:

--- a/azure-templates/steps-post-build.yml
+++ b/azure-templates/steps-post-build.yml
@@ -1,16 +1,14 @@
 parameters:
   - name: packages
     type: object
-  - name: pack
-    type: boolean
 # Note: the following variables are defined in pre-job-steps.yml:
   # nipkgPath, customDeviceRepoName, lvVersion, releaseVersion,
   # quarterlyReleaseVersion shortLvVersion, buildOutputPath,
   # archivePath, architecture
 
 steps:
-  - ${{ if eq( parameters.pack, true )}}:
-    - ${{ each package in parameters.packages }}:
+  - ${{ each package in parameters.packages }}:
+    - ${{ if ne(package.controlFileName, '') }}:
       - task: PowerShell@2
         displayName: Stage nipkg directory
         inputs:

--- a/azure-templates/steps-pre-build.yml
+++ b/azure-templates/steps-pre-build.yml
@@ -40,7 +40,7 @@ steps:
         Write-Host "##vso[task.setvariable variable=buildOutputPath]$customDeviceRepoName\${{ parameters.buildOutputLocation }}"
         Write-Host "##vso[task.setvariable variable=nipkgPath]$customDeviceRepoName\nipkg"
         `
-        Write-Output 'Configuring release version...'
+        Write-Output 'Configuring release version to "${{ parameters.releaseVersion }}"" and quarterlyReleaseVersion to "${{ parameters.quarterlyReleaseVersion }}""...'
         Write-Host '##vso[task.setvariable variable=releaseVersion]${{ parameters.releaseVersion }}'
         Write-Host '##vso[task.setvariable variable=quarterlyReleaseVersion]${{ parameters.quarterlyReleaseVersion }}'
         Write-Host '##vso[task.setvariable variable=lvVersion]${{ parameters.lvVersionToBuild.version }}'


### PR DESCRIPTION
- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-custom-device-build-tools/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

1. changes codegen to work with all build specs (the limitation was based on an old design that was thrown out for the current design).
2. Also removes "pack" parameter, which is not needed now that there is a method for just cycling through "each" of a parameter.
3. Finally, adds an explicit definition of release versions and dependency skipping for troubleshooting

### Why should this Pull Request be merged?

Needed for Scan Engine pipeline development.

### What testing has been done?

See build pipeline results below.