### PR TITLE
Handle more quarterly versions than just 2023 Q1

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -10,7 +10,7 @@ resources:
     - repository: niveristand-custom-device-build-tools
       type:       github
       ref:        main
-      endpoint:   ni (2)
+      endpoint:   nivs-custom-devices
       name:       ni/niveristand-custom-device-build-tools
 
 stages:
@@ -92,8 +92,7 @@ stages:
           target: 'This value does not matter'
           buildSpec: 'This value does not matter'
 
-      releaseVersion: '23.0.0'
-      quarterlyReleaseVersion: '2023 Q1'
+      releaseVersion: '23.3.0'
       buildOutputLocation: 'test-build\Built'
       archiveLocation: '\\nirvana\Measurements\VeriStandAddons\prototype\niveristand-custom-device-build-tools\complexCase'
 
@@ -131,7 +130,6 @@ stages:
           target: 'My Computer'
           buildSpec: 'EmptySpec'
 
-      releaseVersion: '23.0.0'
-      quarterlyReleaseVersion: '2023 Q1'
+      releaseVersion: '23.3.0'
       buildOutputLocation: 'test-build\Built'
       archiveLocation: '\\nirvana\Measurements\VeriStandAddons\prototype\niveristand-custom-device-build-tools\emptyCase'

--- a/azure-templates/stages.yml
+++ b/azure-templates/stages.yml
@@ -34,6 +34,7 @@ parameters:
     type: string
   - name: quarterlyReleaseVersion
     type: string
+    default: 1999
   - name: buildOutputLocation
     type: string
   - name: archiveLocation

--- a/azure-templates/stages.yml
+++ b/azure-templates/stages.yml
@@ -57,7 +57,6 @@ stages:
               parameters:
                 lvVersionToBuild:        ${{ lvVersionToBuild }}
                 releaseVersion:          ${{ parameters.releaseVersion }}
-                quarterlyReleaseVersion: ${{ parameters.quarterlyReleaseVersion }}
                 archiveLocation:         ${{ parameters.archiveLocation }}
                 buildOutputLocation:     ${{ parameters.buildOutputLocation }}
 

--- a/azure-templates/steps-pre-build.yml
+++ b/azure-templates/steps-pre-build.yml
@@ -56,10 +56,10 @@ steps:
         {
           $derivedQuarterlyReleaseVersion = "20$($releaseData[0]) Q4"
         }
-        Write-Output 'Configuring release version to "${{ parameters.releaseVersion }}" and quarterlyReleaseVersion to "$($derivedQuarterlyReleaseVersion)"...'
-        Write-Host '##vso[task.setvariable variable=releaseVersion]${{ parameters.releaseVersion }}'
-        Write-Host '##vso[task.setvariable variable=quarterlyReleaseVersion]$derivedQuarterlyReleaseVersion'
-        Write-Host '##vso[task.setvariable variable=lvVersion]${{ parameters.lvVersionToBuild.version }}'
+        Write-Output "Configuring release version to ${{ parameters.releaseVersion }} and quarterlyReleaseVersion to $($derivedQuarterlyReleaseVersion)..."
+        Write-Host "##vso[task.setvariable variable=releaseVersion]${{ parameters.releaseVersion }}""
+        Write-Host "##vso[task.setvariable variable=quarterlyReleaseVersion]$derivedQuarterlyReleaseVersion"
+        Write-Host "##vso[task.setvariable variable=lvVersion]${{ parameters.lvVersionToBuild.version }}"
         If ('${{ parameters.lvVersionToBuild.bitness }}' -eq '32bit')
         {
           Write-Output "Setting variables for 32-bit..."

--- a/azure-templates/steps-pre-build.yml
+++ b/azure-templates/steps-pre-build.yml
@@ -5,6 +5,7 @@ parameters:
     type: string
   - name: quarterlyReleaseVersion
     type: string
+    default: 1999
   - name: archiveLocation
     type: string
   - name: buildOutputLocation
@@ -40,9 +41,27 @@ steps:
         Write-Host "##vso[task.setvariable variable=buildOutputPath]$customDeviceRepoName\${{ parameters.buildOutputLocation }}"
         Write-Host "##vso[task.setvariable variable=nipkgPath]$customDeviceRepoName\nipkg"
         `
-        Write-Output 'Configuring release version to "${{ parameters.releaseVersion }}"" and quarterlyReleaseVersion to "${{ parameters.quarterlyReleaseVersion }}""...'
+        Write-Output 'Determining quarterlyReleaseVersion...'
+        $releaseData = "${{ parameters.releaseVersion }}" -Split "\."
+        If ($releaseData[1] -eq "0")
+        {
+          $derivedQuarterlyReleaseVersion = "20$($releaseData[0]) Q1"
+        }
+        If ($releaseData[1] -eq "3")
+        {
+        $derivedQuarterlyReleaseVersion = "20$($releaseData[0]) Q2"
+        }
+        If ($releaseData[1] -eq "5")
+        {
+          $derivedQuarterlyReleaseVersion = "20$($releaseData[0]) Q3"
+        }
+        If ($releaseData[1] -eq "8")
+        {
+          $derivedQuarterlyReleaseVersion = "20$($releaseData[0]) Q4"
+        }
+        Write-Output 'Configuring release version to "${{ parameters.releaseVersion }}" and quarterlyReleaseVersion to "$($derivedQuarterlyReleaseVersion)"...'
         Write-Host '##vso[task.setvariable variable=releaseVersion]${{ parameters.releaseVersion }}'
-        Write-Host '##vso[task.setvariable variable=quarterlyReleaseVersion]${{ parameters.quarterlyReleaseVersion }}'
+        Write-Host '##vso[task.setvariable variable=quarterlyReleaseVersion]$derivedQuarterlyReleaseVersion'
         Write-Host '##vso[task.setvariable variable=lvVersion]${{ parameters.lvVersionToBuild.version }}'
         If ('${{ parameters.lvVersionToBuild.bitness }}' -eq '32bit')
         {

--- a/azure-templates/steps-pre-build.yml
+++ b/azure-templates/steps-pre-build.yml
@@ -57,7 +57,7 @@ steps:
           $derivedQuarterlyReleaseVersion = "20$($releaseData[0]) Q4"
         }
         Write-Output "Configuring release version to ${{ parameters.releaseVersion }} and quarterlyReleaseVersion to $($derivedQuarterlyReleaseVersion)..."
-        Write-Host "##vso[task.setvariable variable=releaseVersion]${{ parameters.releaseVersion }}""
+        Write-Host "##vso[task.setvariable variable=releaseVersion]${{ parameters.releaseVersion }}"
         Write-Host "##vso[task.setvariable variable=quarterlyReleaseVersion]$derivedQuarterlyReleaseVersion"
         Write-Host "##vso[task.setvariable variable=lvVersion]${{ parameters.lvVersionToBuild.version }}"
         If ('${{ parameters.lvVersionToBuild.bitness }}' -eq '32bit')

--- a/azure-templates/steps-pre-build.yml
+++ b/azure-templates/steps-pre-build.yml
@@ -3,9 +3,6 @@ parameters:
     type: object
   - name: releaseVersion
     type: string
-  - name: quarterlyReleaseVersion
-    type: string
-    default: 1999
   - name: archiveLocation
     type: string
   - name: buildOutputLocation

--- a/src/ni/vsbuild/packages/AbstractPackage.groovy
+++ b/src/ni/vsbuild/packages/AbstractPackage.groovy
@@ -36,14 +36,31 @@ abstract class AbstractPackage implements Buildable {
    }
 
    protected def getQuarterlyDisplayVersion() {
-      // Rather than try to finalize the versioning policy now,
-      // punt and just handle the immediate case.
-      def baseVersion = getBaseVersion()
-      if (baseVersion == "23.0.0") {
-         return "2023 Q1"
+      // Unclear what the policy is for updates at the time of writing
+      if (getUpdateVersion() == "0") {
+         return baseVersion
       }
 
-      return baseVersion
+      def quarter = ""
+      switch (getMinorVersion()) {
+         case "0":
+            quarter = "1"
+            break
+         case "3":
+            quarter = "2"
+            break
+         case "5":
+            quarter = "3"
+            break
+         case "8":
+            quarter = "4"
+            break
+         default:
+            // Unexpected minor version
+            return baseVersion
+      }
+
+      return "20${getMajorVersion()} Q${quarter}"
    }
 
    protected def getBaseVersion() {


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-custom-device-build-tools/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Follow up to #134 which supports additional versions.

### Why should this Pull Request be merged?

We want packages built this cycle to be versioned "2023 Q2".

### What testing has been done?

PR build.

(Azure Pipeline) Checked the nipkg output:
![image](https://user-images.githubusercontent.com/42351034/222823995-36f552af-d96e-4afe-9b56-93a3ab82cbb0.png)
