### PR TITLE
Move pipeline to use DevCentral

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -10,7 +10,7 @@ resources:
     - repository: niveristand-custom-device-build-tools
       type:       github
       ref:        main
-      endpoint:   ni
+      endpoint:   nivs-custom-devices
       name:       ni/niveristand-custom-device-build-tools
 
 stages:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -10,7 +10,7 @@ resources:
     - repository: niveristand-custom-device-build-tools
       type:       github
       ref:        main
-      endpoint:   ni (2)
+      endpoint:   ni
       name:       ni/niveristand-custom-device-build-tools
 
 stages:

--- a/azure-templates/stages.yml
+++ b/azure-templates/stages.yml
@@ -44,7 +44,7 @@ stages:
   - stage: ${{ parameters.stageName }}
     dependsOn: []
     pool:
-      name: custom-device-temp # TEMPORARY, eventually use an official build pool of custom device agents!!
+      name: DevCentral-VeriStand-CustomDevices
       demands:
         - agent.os -equals Windows_NT
     jobs:
@@ -72,7 +72,7 @@ stages:
               parameters:
                 packages: ${{ parameters.packages }}
 
-        # if all jobs have passed, place .finished file in top level archive location TEMPORARY - linked to imitation-cd instead of build-tools
+        # if all jobs have passed, place .finished file in top level archive location
       - job: Finalize
         displayName: Final Validation
         dependsOn:


### PR DESCRIPTION
- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-custom-device-build-tools/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Update pipeline to use DevCentral instead of Users project.

### Why should this Pull Request be merged?

This is necessary to move the builds to DevCentral.

### What testing has been done?

Will run the pipeline as part of this PR.