### PR TITLE
Move out of prototype location, remove quarterly release parameter

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -33,13 +33,13 @@ stages:
 
 # Test Dependencies - multiple dependencies that are expected in the build steps below this
       dependencies:
-        - source: '\\nirvana\Measurements\VeriStandAddons\prototype\dependency-test-1'
+        - source: '\\nirvana\Measurements\VeriStandAddons\build_tools_test\dependency-test-1'
           file: 'DependencyLibrary1.lvlibp'
           destination: 'test-build\Includes'
-        - source: '\\nirvana\Measurements\VeriStandAddons\prototype\dependency-test-2'
+        - source: '\\nirvana\Measurements\VeriStandAddons\build_tools_test\dependency-test-2'
           file: 'DependencyLibrary2.lvlibp'
           destination: 'test-build\Other\Includes'
-        - source: '\\nirvana\Measurements\VeriStandAddons\prototype\dependency-test-3'
+        - source: '\\nirvana\Measurements\VeriStandAddons\build_tools_test\dependency-test-3'
           file: 'DependencyLibrary3.lvlibp'
           destination: 'test-build\Other\Includes'
 
@@ -94,7 +94,7 @@ stages:
 
       releaseVersion: '23.3.0'
       buildOutputLocation: 'test-build\Built'
-      archiveLocation: '\\nirvana\Measurements\VeriStandAddons\prototype\niveristand-custom-device-build-tools\complexCase'
+      archiveLocation: '\\nirvana\Measurements\VeriStandAddons\build_tools_test\niveristand-custom-device-build-tools\complexCase'
 
 # Test Building multiple packages with multiple payload maps
       packages:
@@ -132,4 +132,4 @@ stages:
 
       releaseVersion: '23.3.0'
       buildOutputLocation: 'test-build\Built'
-      archiveLocation: '\\nirvana\Measurements\VeriStandAddons\prototype\niveristand-custom-device-build-tools\emptyCase'
+      archiveLocation: '\\nirvana\Measurements\VeriStandAddons\build_tools_test\niveristand-custom-device-build-tools\emptyCase'

--- a/azure-templates/stages.yml
+++ b/azure-templates/stages.yml
@@ -32,9 +32,6 @@ parameters:
   # strings (releaseVersion, quarterlyReleaseVersion, buildOutputLocation, archiveLocation)
   - name: releaseVersion
     type: string
-  - name: quarterlyReleaseVersion
-    type: string
-    default: 1999
   - name: buildOutputLocation
     type: string
   - name: archiveLocation


### PR DESCRIPTION
- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-custom-device-build-tools/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Remove the quarterlyReleaseVersion, which was set to default to avoid breakage while it was removed from dependents.  Move archive from prototype location to a build_tools_test location now that things are working smoothly.

### Why should this Pull Request be merged?

cleanup of unused and prototype items.

### What testing has been done?

PR Build should build in correct location with no errors.