### PR TITLE
Fix branch name

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -33,13 +33,13 @@ stages:
 
 # Test Dependencies - multiple dependencies that are expected in the build steps below this
       dependencies:
-        - source: '\\nirvana\Measurements\VeriStandAddons\build_tools_test\dependency-test-1'
+        - source: '\\nirvana\Measurements\VeriStandAddons\prototype\dependency-test-1'
           file: 'DependencyLibrary1.lvlibp'
           destination: 'test-build\Includes'
-        - source: '\\nirvana\Measurements\VeriStandAddons\build_tools_test\dependency-test-2'
+        - source: '\\nirvana\Measurements\VeriStandAddons\prototype\dependency-test-2'
           file: 'DependencyLibrary2.lvlibp'
           destination: 'test-build\Other\Includes'
-        - source: '\\nirvana\Measurements\VeriStandAddons\build_tools_test\dependency-test-3'
+        - source: '\\nirvana\Measurements\VeriStandAddons\prototype\dependency-test-3'
           file: 'DependencyLibrary3.lvlibp'
           destination: 'test-build\Other\Includes'
 
@@ -94,7 +94,7 @@ stages:
 
       releaseVersion: '23.3.0'
       buildOutputLocation: 'test-build\Built'
-      archiveLocation: '\\nirvana\Measurements\VeriStandAddons\build_tools_test\niveristand-custom-device-build-tools\complexCase'
+      archiveLocation: '\\nirvana\Measurements\VeriStandAddons\prototype\niveristand-custom-device-build-tools\complexCase'
 
 # Test Building multiple packages with multiple payload maps
       packages:
@@ -132,4 +132,4 @@ stages:
 
       releaseVersion: '23.3.0'
       buildOutputLocation: 'test-build\Built'
-      archiveLocation: '\\nirvana\Measurements\VeriStandAddons\build_tools_test\niveristand-custom-device-build-tools\emptyCase'
+      archiveLocation: '\\nirvana\Measurements\VeriStandAddons\prototype\niveristand-custom-device-build-tools\emptyCase'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -33,13 +33,13 @@ stages:
 
 # Test Dependencies - multiple dependencies that are expected in the build steps below this
       dependencies:
-        - source: '\\nirvana\Measurements\VeriStandAddons\prototype\dependency-test-1'
+        - source: '\\nirvana\Measurements\VeriStandAddons\build_tools_test\dependency-test-1'
           file: 'DependencyLibrary1.lvlibp'
           destination: 'test-build\Includes'
-        - source: '\\nirvana\Measurements\VeriStandAddons\prototype\dependency-test-2'
+        - source: '\\nirvana\Measurements\VeriStandAddons\build_tools_test\dependency-test-2'
           file: 'DependencyLibrary2.lvlibp'
           destination: 'test-build\Other\Includes'
-        - source: '\\nirvana\Measurements\VeriStandAddons\prototype\dependency-test-3'
+        - source: '\\nirvana\Measurements\VeriStandAddons\build_tools_test\dependency-test-3'
           file: 'DependencyLibrary3.lvlibp'
           destination: 'test-build\Other\Includes'
 
@@ -94,7 +94,7 @@ stages:
 
       releaseVersion: '23.3.0'
       buildOutputLocation: 'test-build\Built'
-      archiveLocation: '\\nirvana\Measurements\VeriStandAddons\prototype\niveristand-custom-device-build-tools\complexCase'
+      archiveLocation: '\\nirvana\Measurements\VeriStandAddons\build_tools_test\niveristand-custom-device-build-tools\complexCase'
 
 # Test Building multiple packages with multiple payload maps
       packages:
@@ -132,4 +132,4 @@ stages:
 
       releaseVersion: '23.3.0'
       buildOutputLocation: 'test-build\Built'
-      archiveLocation: '\\nirvana\Measurements\VeriStandAddons\prototype\niveristand-custom-device-build-tools\emptyCase'
+      archiveLocation: '\\nirvana\Measurements\VeriStandAddons\build_tools_test\niveristand-custom-device-build-tools\emptyCase'

--- a/azure-templates/stages.yml
+++ b/azure-templates/stages.yml
@@ -85,12 +85,14 @@ stages:
             If ('$(Build.Reason)' -eq 'PullRequest')
             {
               Write-Output "Setting variables for Pull Requests..."
-              $sourceBranch = "$(System.PullRequest.SourceBranch)" -replace 'dev/', ''
+              $sourceBranch = "$(System.PullRequest.SourceBranch)"
+              Write-Output "Source branch $(System.PullRequest.SourceBranch)"
             }
             Else
             {
               Write-Output "Setting variables for general builds..."
-              $sourceBranch = "$(Build.SourceBranchName)"
+              $sourceBranch = "$(Build.SourceBranch)" -replace 'refs/heads/', ''
+              Write-Output "Source branch $(Build.SourceBranch), removed refs/heads/"
             }
             Write-Output "Using $sourceBranch in final validation path..."
             Write-Output "All previous jobs complete.  Storing .finished file..."

--- a/azure-templates/stages.yml
+++ b/azure-templates/stages.yml
@@ -32,6 +32,9 @@ parameters:
   # strings (releaseVersion, quarterlyReleaseVersion, buildOutputLocation, archiveLocation)
   - name: releaseVersion
     type: string
+  - name: quarterlyReleaseVersion
+    type: string
+    default: 1999
   - name: buildOutputLocation
     type: string
   - name: archiveLocation

--- a/azure-templates/stages.yml
+++ b/azure-templates/stages.yml
@@ -32,9 +32,6 @@ parameters:
   # strings (releaseVersion, quarterlyReleaseVersion, buildOutputLocation, archiveLocation)
   - name: releaseVersion
     type: string
-  - name: quarterlyReleaseVersion
-    type: string
-    default: 1999
   - name: buildOutputLocation
     type: string
   - name: archiveLocation

--- a/azure-templates/steps-pre-build.yml
+++ b/azure-templates/steps-pre-build.yml
@@ -26,13 +26,14 @@ steps:
         {
           Write-Output "Setting variables for Pull Requests..."
           $sourceBranch = "$(System.PullRequest.SourceBranch)" -replace 'dev/', ''
+          Write-Output "Source branch $(System.PullRequest.SourceBranch), removed dev/"
         }
         Else
         {
           Write-Output "Setting variables for general builds..."
-          $sourceBranch = "$(Build.SourceBranchName)"
+          $sourceBranch = "$(System.SourceBranch)" -replace 'refs/head/dev/', ''
+          Write-Output "Source branch $(System.SourceBranch), removed refs/head/dev/"
         }
-        Write-Output "WHAT IS $(Build.SourceBranch)"
         Write-Output "Using $sourceBranch in archive path..."
         Write-Host "##vso[task.setvariable variable=sourceBranch]$sourceBranch"
         Write-Host "##vso[task.setvariable variable=archivePath]${{ parameters.archiveLocation }}\NI\export\$sourceBranch\"

--- a/azure-templates/steps-pre-build.yml
+++ b/azure-templates/steps-pre-build.yml
@@ -25,14 +25,14 @@ steps:
         If ('$(Build.Reason)' -eq 'PullRequest')
         {
           Write-Output "Setting variables for Pull Requests..."
-          $sourceBranch = "$(System.PullRequest.SourceBranch)" -replace 'dev/', ''
-          Write-Output "Source branch $(System.PullRequest.SourceBranch), removed dev/"
+          $sourceBranch = "$(System.PullRequest.SourceBranch)"
+          Write-Output "Source branch $(System.PullRequest.SourceBranch)"
         }
         Else
         {
           Write-Output "Setting variables for general builds..."
-          $sourceBranch = "$(System.SourceBranch)" -replace 'refs/head/dev/', ''
-          Write-Output "Source branch $(System.SourceBranch), removed refs/head/dev/"
+          $sourceBranch = "$(Build.SourceBranch)" -replace 'refs/head/', ''
+          Write-Output "Source branch $(Build.SourceBranch), removed refs/head/"
         }
         Write-Output "Using $sourceBranch in archive path..."
         Write-Host "##vso[task.setvariable variable=sourceBranch]$sourceBranch"

--- a/azure-templates/steps-pre-build.yml
+++ b/azure-templates/steps-pre-build.yml
@@ -31,8 +31,8 @@ steps:
         Else
         {
           Write-Output "Setting variables for general builds..."
-          $sourceBranch = "$(Build.SourceBranch)" -replace 'refs/head/', ''
-          Write-Output "Source branch $(Build.SourceBranch), removed refs/head/"
+          $sourceBranch = "$(Build.SourceBranch)" -replace 'refs/heads/', ''
+          Write-Output "Source branch $(Build.SourceBranch), removed refs/heads/"
         }
         Write-Output "Using $sourceBranch in archive path..."
         Write-Host "##vso[task.setvariable variable=sourceBranch]$sourceBranch"

--- a/azure-templates/steps-pre-build.yml
+++ b/azure-templates/steps-pre-build.yml
@@ -32,6 +32,7 @@ steps:
           Write-Output "Setting variables for general builds..."
           $sourceBranch = "$(Build.SourceBranchName)"
         }
+        Write-Output "WHAT IS $(Build.SourceBranch)"
         Write-Output "Using $sourceBranch in archive path..."
         Write-Host "##vso[task.setvariable variable=sourceBranch]$sourceBranch"
         Write-Host "##vso[task.setvariable variable=archivePath]${{ parameters.archiveLocation }}\NI\export\$sourceBranch\"


### PR DESCRIPTION
- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-custom-device-build-tools/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

source branch export path will now include any /* as directories (including dev and release, as well as others if used)
### Why should this Pull Request be merged?

Release branch naming convention is release/XX.X, which currently cuts release from the path.

### What testing has been done?

PR build outputs now save with the dev path in this branch for both PR builds (see output of this PR) and generic branch builds (see screenshot):
![image](https://user-images.githubusercontent.com/42351034/223826989-4e570db0-c9e7-4dd6-8bea-c096e73da727.png)

