### PR TITLE
Add a Build Counter to iterate at the end of each nipkg_version of nipkg output

### DIFF
--- a/azure-templates/stages.yml
+++ b/azure-templates/stages.yml
@@ -50,7 +50,10 @@ stages:
         - agent.os -equals Windows_NT
     # build counter is used to label nipkg output - it cannot be defined inside of the templates below due to restrictions with the "counter" function
     variables:
-      buildCounter: $[counter(variables['Build.SourceBranch'], 1)]
+      ${{ if ne(variables['Build.Reason'], 'PullRequest')}}:
+        buildCounter: $[counter(variables['Build.SourceBranch'], 1)]
+      ${{ if eq(variables['Build.Reason'], 'PullRequest')}}:
+        buildCounter: "9999"
     jobs:
       - ${{ each lvVersionToBuild in parameters.lvVersionsToBuild }}:
         - job: Job${{ lvVersionToBuild.version }}_${{ lvVersionToBuild.bitness }}

--- a/azure-templates/stages.yml
+++ b/azure-templates/stages.yml
@@ -48,6 +48,9 @@ stages:
       name: DevCentral-VeriStand-CustomDevices
       demands:
         - agent.os -equals Windows_NT
+    # build counter is used to label nipkg output - it cannot be defined inside of the templates below due to restrictions with the "counter" function
+    variables:
+      buildCounter: $[counter(variables['Build.SourceBranch'], 1)]
     jobs:
       - ${{ each lvVersionToBuild in parameters.lvVersionsToBuild }}:
         - job: Job${{ lvVersionToBuild.version }}_${{ lvVersionToBuild.bitness }}

--- a/azure-templates/steps-post-build.yml
+++ b/azure-templates/steps-post-build.yml
@@ -72,21 +72,21 @@ steps:
               -Include *.nipkg `
               -Recurse
             Write-Output "Checking whether this is a release branch..."
-            If (-not("$(sourceBranch)" -match "release"))
-            {
-              $cleanedSourceBranch = "$(sourceBranch)" -replace "\/", ""
-              Write-Output "Not a release branch, so appending branch name $cleanedSourceBranch to nipkg..."
-              Get-ChildItem `
-                -Path "$installerPath\*.nipkg" `
-                | Rename-Item -NewName {$_.Name -replace ".nipkg", "$cleanedSourceBranch.nipkg"}
-            }
-
 
   - task: PowerShell@2
     displayName: Copy built files to Archive location
     inputs:
       targetType: 'inline'
       script: |
+        If (-not("$(sourceBranch)" -match "release"))
+        {
+          $cleanedSourceBranch = "$(sourceBranch)" -replace "\/", ""
+          Write-Output "Not a release branch, so appending branch name $cleanedSourceBranch to nipkg files..."
+          Get-ChildItem `
+            -Path "$(archivePath)\$(Build.BuildNumber)\$(lvVersion)\installer\*.nipkg" `
+            | Rename-Item -NewName {$_.Name -replace ".nipkg", "$cleanedSourceBranch.nipkg"}
+        }
+
         If (-not(Test-Path "$(archivePath)\$(Build.BuildNumber)\$(lvVersion)\$(architecture)"))
         {
           New-Item `

--- a/azure-templates/steps-post-build.yml
+++ b/azure-templates/steps-post-build.yml
@@ -28,11 +28,11 @@ steps:
               -Path '$(customDeviceRepoName)\${{ package.controlFileName }}' `
               -Destination '$(nipkgPath)\control\control'
             `
-            Write-Output "updating nipkg control version parameters..."
+            Write-Output "updating nipkg control version parameters, setting nipkg_version to $(releaseVersion)$env:BUILDCOUNTER..."
             $contents = (Get-Content -Path '$(nipkgPath)\control\control')`
               -replace '{veristand_version}', '$(lvVersion)'`
               -replace '{labview_version}', '$(lvVersion)'`
-              -replace '{nipkg_version}', '$(releaseVersion)'`
+              -replace '{nipkg_version}', '$(releaseVersion)$env:BUILDCOUNTER'`
               -replace '{display_version}', '$(releaseVersion)'`
               -replace '{quarterly_display_version}', '$(quarterlyReleaseVersion)'`
               -replace '{labview_short_version}', '$(shortLvVersion)'

--- a/azure-templates/steps-post-build.yml
+++ b/azure-templates/steps-post-build.yml
@@ -75,7 +75,7 @@ steps:
             If (-not($(Build.SourceBranch) -match "release"))
             {
               Write-Output "Not a release branch, so appending branch name to nipkg..."
-              $cleanedSourceBranch = $sourceBranch -replace "\\", ""
+              $cleanedSourceBranch = "$sourceBranch" -replace "\/", ""
               Get-ChildItem `
                 -Path "$installerPath\*.nipkg" `
                 | Rename-Item -NewName {$_.Name -replace ".nipkg", "$cleanedSourceBranch\.nipkg"}

--- a/azure-templates/steps-post-build.yml
+++ b/azure-templates/steps-post-build.yml
@@ -28,7 +28,7 @@ steps:
               -Path '$(customDeviceRepoName)\${{ package.controlFileName }}' `
               -Destination '$(nipkgPath)\control\control'
             `
-            Write-Output "updating nipkg control version parameters, setting nipkg_version to $(releaseVersion).$env:BUILDCOUNTER..."
+            Write-Output "updating nipkg control version parameters..."
             $contents = (Get-Content -Path "$(nipkgPath)\control\control") `
               -replace "{veristand_version}", "$(lvVersion)" `
               -replace "{labview_version}", "$(lvVersion)" `
@@ -71,6 +71,16 @@ steps:
               -Destination $installerPath `
               -Include *.nipkg `
               -Recurse
+            Write-Output "Checking whether this is a release branch..."
+            If (-not($(Build.SourceBranch) -match "release"))
+            {
+              Write-Output "Not a release branch, so appending branch name to nipkg..."
+              $cleanedSourceBranch = $sourceBranch -replace "\\", ""
+              Get-ChildItem `
+                -Path "$installerPath\*.nipkg" `
+                | Rename-Item -NewName {$_.Name -replace ".nipkg", "$cleanedSourceBranch\.nipkg"}
+            }
+
 
   - task: PowerShell@2
     displayName: Copy built files to Archive location

--- a/azure-templates/steps-post-build.yml
+++ b/azure-templates/steps-post-build.yml
@@ -92,7 +92,7 @@ steps:
           {
             If (-not("$package" -match "$cleanedSourceBranch.nipkg"))
             {
-              Rename-Item -NewName {"$package" -replace "(?!).nipkg", "$cleanedSourceBranch.nipkg"}
+              Rename-Item -NewName "$package" -replace ".nipkg", "$cleanedSourceBranch.nipkg"
             }
           }
         }

--- a/azure-templates/steps-post-build.yml
+++ b/azure-templates/steps-post-build.yml
@@ -92,7 +92,7 @@ steps:
           {
             If (-not("$package" -match "$cleanedSourceBranch.nipkg"))
             {
-              Rename-Item -NewName {$package -replace "(?!).nipkg", "$cleanedSourceBranch.nipkg"}
+              Rename-Item -NewName {"$package" -replace "(?!).nipkg", "$cleanedSourceBranch.nipkg"}
             }
           }
         }

--- a/azure-templates/steps-post-build.yml
+++ b/azure-templates/steps-post-build.yml
@@ -92,7 +92,7 @@ steps:
           {
             If (-not("$package" -match "$cleanedSourceBranch.nipkg"))
             {
-              Rename-Item -NewName "$package" -replace ".nipkg", "$cleanedSourceBranch.nipkg"
+              Rename-Item -NewName ("$package" -replace ".nipkg", "$cleanedSourceBranch.nipkg")
             }
           }
         }

--- a/azure-templates/steps-post-build.yml
+++ b/azure-templates/steps-post-build.yml
@@ -88,7 +88,10 @@ steps:
           Write-Output "Not a release branch, so appending branch name $cleanedSourceBranch to nipkg files..."
           Get-ChildItem `
             -Path "$(archivePath)\$(Build.BuildNumber)\$(lvVersion)\installer\*.nipkg" `
-            | Rename-Item -NewName {$_.Name -replace ".nipkg", "$cleanedSourceBranch.nipkg"}
+            | If (-not("$_.Name" -match "$cleanedSourceBranch.nipkg"))
+              {
+                Rename-Item -NewName {$_.Name -replace "(?!).nipkg", "$cleanedSourceBranch.nipkg"}
+              }
         }
 
         If (-not(Test-Path "$(archivePath)\$(Build.BuildNumber)\$(lvVersion)\$(architecture)"))

--- a/azure-templates/steps-post-build.yml
+++ b/azure-templates/steps-post-build.yml
@@ -84,7 +84,7 @@ steps:
       script: |
         If (-not("$(sourceBranch)" -match "release"))
         {
-          $cleanedSourceBranch = "$(sourceBranch)" -replace "\/", ""
+          $cleanedSourceBranch = "$(sourceBranch)" -replace "\/", "_"
           Write-Output "Not a release branch, so appending branch name $cleanedSourceBranch to nipkg files..."
           $packages = Get-ChildItem `
             -Path "$(archivePath)\$(Build.BuildNumber)\$(lvVersion)\installer\*.nipkg"

--- a/azure-templates/steps-post-build.yml
+++ b/azure-templates/steps-post-build.yml
@@ -92,7 +92,7 @@ steps:
           {
             If (-not("$package" -match "$cleanedSourceBranch.nipkg"))
             {
-              Rename-Item -Path "$package" -NewName ("$package" -replace ".nipkg", "$cleanedSourceBranch.nipkg")
+              Rename-Item -Path "$package" -NewName ("$package" -replace ".nipkg", "_$cleanedSourceBranch.nipkg")
             }
           }
         }

--- a/azure-templates/steps-post-build.yml
+++ b/azure-templates/steps-post-build.yml
@@ -1,3 +1,6 @@
+# IMPORTANT: Any changes made to this file may need to be duplicated in 
+# ni/niveristand-scan-engine-ethercat-custom-device/custom-packaging.yml
+
 parameters:
   - name: packages
     type: object

--- a/azure-templates/steps-post-build.yml
+++ b/azure-templates/steps-post-build.yml
@@ -92,7 +92,7 @@ steps:
           {
             If (-not("$package" -match "$cleanedSourceBranch.nipkg"))
             {
-              Rename-Item -NewName ("$package" -replace ".nipkg", "$cleanedSourceBranch.nipkg")
+              Rename-Item -Path "$package" -NewName ("$package" -replace ".nipkg", "$cleanedSourceBranch.nipkg")
             }
           }
         }

--- a/azure-templates/steps-post-build.yml
+++ b/azure-templates/steps-post-build.yml
@@ -35,7 +35,8 @@ steps:
               -replace "{nipkg_version}", "$(releaseVersion).$env:BUILDCOUNTER" `
               -replace "{display_version}", "$(releaseVersion)" `
               -replace "{quarterly_display_version}", "$(quarterlyReleaseVersion)" `
-              -replace "{labview_short_version}", "$(shortLvVersion)"
+              -replace "{labview_short_version}", "$(shortLvVersion)" `
+              -replace "{nipkgx64suffix}", "$(nipkgx64suffix)"
             Write-Output $contents
             Set-Content -Value $contents -Path "$(nipkgPath)\control\control"
 

--- a/azure-templates/steps-post-build.yml
+++ b/azure-templates/steps-post-build.yml
@@ -72,7 +72,7 @@ steps:
               -Include *.nipkg `
               -Recurse
             Write-Output "Checking whether this is a release branch..."
-            If (-not($(Build.SourceBranch) -match "release"))
+            If (-not("$(sourceBranch)" -match "release"))
             {
               Write-Output "Not a release branch, so appending branch name to nipkg..."
               $cleanedSourceBranch = "$(sourceBranch)" -replace "\/", ""

--- a/azure-templates/steps-post-build.yml
+++ b/azure-templates/steps-post-build.yml
@@ -29,15 +29,15 @@ steps:
               -Destination '$(nipkgPath)\control\control'
             `
             Write-Output "updating nipkg control version parameters, setting nipkg_version to $(releaseVersion).$env:BUILDCOUNTER..."
-            $contents = (Get-Content -Path '$(nipkgPath)\control\control')`
-              -replace '{veristand_version}', '$(lvVersion)'`
-              -replace '{labview_version}', '$(lvVersion)'`
-              -replace '{nipkg_version}', '$(releaseVersion).$env:BUILDCOUNTER'`
-              -replace '{display_version}', '$(releaseVersion)'`
-              -replace '{quarterly_display_version}', '$(quarterlyReleaseVersion)'`
-              -replace '{labview_short_version}', '$(shortLvVersion)'
+            $contents = (Get-Content -Path "$(nipkgPath)\control\control") `
+              -replace "{veristand_version}", "$(lvVersion)" `
+              -replace "{labview_version}", "$(lvVersion)" `
+              -replace "{nipkg_version}", "$(releaseVersion).$env:BUILDCOUNTER" `
+              -replace "{display_version}", "$(releaseVersion)" `
+              -replace "{quarterly_display_version}", "$(quarterlyReleaseVersion)" `
+              -replace "{labview_short_version}", "$(shortLvVersion)"
             Write-Output $contents
-            Set-Content -Value $contents -Path '$(nipkgPath)\control\control'
+            Set-Content -Value $contents -Path "$(nipkgPath)\control\control"
 
       - ${{ each payloadMap in package.payloadMaps }}:
         - task: PowerShell@2

--- a/azure-templates/steps-post-build.yml
+++ b/azure-templates/steps-post-build.yml
@@ -74,11 +74,11 @@ steps:
             Write-Output "Checking whether this is a release branch..."
             If (-not("$(sourceBranch)" -match "release"))
             {
-              Write-Output "Not a release branch, so appending branch name to nipkg..."
               $cleanedSourceBranch = "$(sourceBranch)" -replace "\/", ""
+              Write-Output "Not a release branch, so appending branch name $cleanedSourceBranch to nipkg..."
               Get-ChildItem `
                 -Path "$installerPath\*.nipkg" `
-                | Rename-Item -NewName {$_.Name -replace ".nipkg", "$cleanedSourceBranch\.nipkg"}
+                | Rename-Item -NewName {$_.Name -replace ".nipkg", "$cleanedSourceBranch.nipkg"}
             }
 
 

--- a/azure-templates/steps-post-build.yml
+++ b/azure-templates/steps-post-build.yml
@@ -90,9 +90,9 @@ steps:
             -Path "$(archivePath)\$(Build.BuildNumber)\$(lvVersion)\installer\*.nipkg"
           Foreach ($package in $packages)
           {
-            If (-not("$_.Name" -match "$cleanedSourceBranch.nipkg"))
+            If (-not("$package" -match "$cleanedSourceBranch.nipkg"))
             {
-              Rename-Item -NewName {$_.Name -replace "(?!).nipkg", "$cleanedSourceBranch.nipkg"}
+              Rename-Item -NewName {$package -replace "(?!).nipkg", "$cleanedSourceBranch.nipkg"}
             }
           }
         }

--- a/azure-templates/steps-post-build.yml
+++ b/azure-templates/steps-post-build.yml
@@ -75,7 +75,7 @@ steps:
             If (-not($(Build.SourceBranch) -match "release"))
             {
               Write-Output "Not a release branch, so appending branch name to nipkg..."
-              $cleanedSourceBranch = "$sourceBranch" -replace "\/", ""
+              $cleanedSourceBranch = "$(sourceBranch)" -replace "\/", ""
               Get-ChildItem `
                 -Path "$installerPath\*.nipkg" `
                 | Rename-Item -NewName {$_.Name -replace ".nipkg", "$cleanedSourceBranch\.nipkg"}

--- a/azure-templates/steps-post-build.yml
+++ b/azure-templates/steps-post-build.yml
@@ -86,12 +86,15 @@ steps:
         {
           $cleanedSourceBranch = "$(sourceBranch)" -replace "\/", ""
           Write-Output "Not a release branch, so appending branch name $cleanedSourceBranch to nipkg files..."
-          Get-ChildItem `
-            -Path "$(archivePath)\$(Build.BuildNumber)\$(lvVersion)\installer\*.nipkg" `
-            | If (-not("$_.Name" -match "$cleanedSourceBranch.nipkg"))
-              {
-                Rename-Item -NewName {$_.Name -replace "(?!).nipkg", "$cleanedSourceBranch.nipkg"}
-              }
+          $packages = Get-ChildItem `
+            -Path "$(archivePath)\$(Build.BuildNumber)\$(lvVersion)\installer\*.nipkg"
+          Foreach ($package in $packages)
+          {
+            If (-not("$_.Name" -match "$cleanedSourceBranch.nipkg"))
+            {
+              Rename-Item -NewName {$_.Name -replace "(?!).nipkg", "$cleanedSourceBranch.nipkg"}
+            }
+          }
         }
 
         If (-not(Test-Path "$(archivePath)\$(Build.BuildNumber)\$(lvVersion)\$(architecture)"))

--- a/azure-templates/steps-post-build.yml
+++ b/azure-templates/steps-post-build.yml
@@ -28,11 +28,11 @@ steps:
               -Path '$(customDeviceRepoName)\${{ package.controlFileName }}' `
               -Destination '$(nipkgPath)\control\control'
             `
-            Write-Output "updating nipkg control version parameters, setting nipkg_version to $(releaseVersion)$env:BUILDCOUNTER..."
+            Write-Output "updating nipkg control version parameters, setting nipkg_version to $(releaseVersion).$env:BUILDCOUNTER..."
             $contents = (Get-Content -Path '$(nipkgPath)\control\control')`
               -replace '{veristand_version}', '$(lvVersion)'`
               -replace '{labview_version}', '$(lvVersion)'`
-              -replace '{nipkg_version}', '$(releaseVersion)$env:BUILDCOUNTER'`
+              -replace '{nipkg_version}', '$(releaseVersion).$env:BUILDCOUNTER'`
               -replace '{display_version}', '$(releaseVersion)'`
               -replace '{quarterly_display_version}', '$(quarterlyReleaseVersion)'`
               -replace '{labview_short_version}', '$(shortLvVersion)'

--- a/test-build/control-a
+++ b/test-build/control-a
@@ -1,4 +1,4 @@
-Package: ni-veristand-{veristand_version}-test-package
+Package: ni-veristand-{veristand_version}-test-package{nipkgx64suffix}
 Version: {nipkg_version}
 Architecture: windows_x64
 Maintainer: National Instruments <support@ni.com>

--- a/test-build/control-b
+++ b/test-build/control-b
@@ -1,4 +1,4 @@
-Package: ni-veristand-{veristand_version}-test-package-2
+Package: ni-veristand-{veristand_version}-test-package-2{nipkgx64suffix}
 Version: {nipkg_version}
 Architecture: windows_x64
 Maintainer: National Instruments <support@ni.com>


### PR DESCRIPTION
- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-custom-device-build-tools/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

* Adds a buildCounter variable that will iterate for each branch for each build.
* Sets buildCounter for PR builds to 9999
* Adds the branch name to nipkg outputs from nonrelease branches
* Add a variable to the control files to not duplicate packages since packaging is done for both bitnesses
* Add comment pointing an editor to scan engine custom device custom packaging

### Why should this Pull Request be merged?

This is useful to help differentiate between different packages from the release branches, and it is used by some of the logic for release.

### What testing has been done?

Ran three instances covered by the changes: 
1. PR build (use 9999 instead of buildCounter), 
2. manual build (works like CI), use buildCounter and append dev branch name
3. new branch with "release" in the name, use buildCounter, but don't append branch name

![image](https://user-images.githubusercontent.com/42351034/224802385-5bc0eff1-1e2b-4f08-9a6c-670deb25e592.png)