### PR TITLE
Add manifest file for release branch builds

### DIFF
--- a/azure-templates/steps-post-build.yml
+++ b/azure-templates/steps-post-build.yml
@@ -107,3 +107,25 @@ steps:
           -Path "$(buildOutputPath)\*" `
           -Destination "$(archivePath)\$(Build.BuildNumber)\$(lvVersion)\$(architecture)\" `
           -Recurse
+
+  - task: PowerShell@2
+    displayName: Create manifest file
+    inputs:
+      targetType: 'inline'
+      script: |
+        If ("$(sourceBranch)" -match "release")
+        {
+          Write-Output "Adding manifest file to release branch installer directory"
+          $jsonFilePath = '$(archivePath)\$(Build.BuildNumber)\$(lvVersion)\installer\manifest.json'
+          Write-Output "Adding manifest file"
+          $scmObject = [PSCustomObject]@{
+            GIT_BRANCH = "$(sourceBranch)"
+            GIT_COMMIT = "$(Build.SourceVersion)"
+            GIT_URL = "$(Build.Repository.Uri)"
+          }
+          $outputObject = [PSCustomObject]@{
+            scm = $scmObject
+          }
+          $jsonString = $outputObject | ConvertTo-Json
+          Set-Content -Path $jsonFilePath -Value $jsonString
+        }

--- a/azure-templates/steps-post-build.yml
+++ b/azure-templates/steps-post-build.yml
@@ -113,11 +113,11 @@ steps:
     inputs:
       targetType: 'inline'
       script: |
-        If ("$(sourceBranch)" -match "release")
+        $installerPath = '$(archivePath)\$(Build.BuildNumber)\$(lvVersion)\installer'
+        If ( ("$(sourceBranch)" -match "release") -and (-not(Test-Path $installerPath)) )
         {
           Write-Output "Adding manifest file to release branch installer directory"
-          $jsonFilePath = '$(archivePath)\$(Build.BuildNumber)\$(lvVersion)\installer\manifest.json'
-          Write-Output "Adding manifest file"
+          $jsonFilePath = Join-Path $installerPath "manifest.json"
           $scmObject = [PSCustomObject]@{
             GIT_BRANCH = "$(sourceBranch)"
             GIT_COMMIT = "$(Build.SourceVersion)"
@@ -128,4 +128,8 @@ steps:
           }
           $jsonString = $outputObject | ConvertTo-Json
           Set-Content -Path $jsonFilePath -Value $jsonString
+        }
+        Else
+        {
+          Write-Output "No release branch packages built; skipping manifest file"
         }

--- a/azure-templates/steps-post-build.yml
+++ b/azure-templates/steps-post-build.yml
@@ -114,7 +114,7 @@ steps:
       targetType: 'inline'
       script: |
         $installerPath = '$(archivePath)\$(Build.BuildNumber)\$(lvVersion)\installer'
-        If ( ("$(sourceBranch)" -match "release") -and (-not(Test-Path $installerPath)) )
+        If ( ("$(sourceBranch)" -match "release") -and (Test-Path $installerPath) )
         {
           Write-Output "Adding manifest file to release branch installer directory"
           $jsonFilePath = Join-Path $installerPath "manifest.json"


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-custom-device-build-tools/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Add manifest file with git branch, commit, and URL for release builds

### Why should this Pull Request be merged?

The manifest file is still used by the feed creation and ATS events to specify which branch, commit, and URL to clone to run tests against. This replaces the groovy logic that created the file for Jenkins builds.

### What testing has been done?

Ran the build pipeline against this dev branch and an identical release/23.3 branch to test both cases:
[dev branch build](https://dev.azure.com/ni/DevCentral/_build/results?buildId=4456834&view=logs&j=d776b11b-d2bf-5943-1b8d-603570db92c3&t=8e9e3714-0ae4-56f4-d6c9-e7a9c6354283)
[release branch build](https://dev.azure.com/ni/DevCentral/_build/results?buildId=4456831&view=logs&j=d776b11b-d2bf-5943-1b8d-603570db92c3&t=8e9e3714-0ae4-56f4-d6c9-e7a9c6354283)