### PR TITLE
Add x86 suffix for packaging

### DIFF
--- a/azure-templates/steps-post-build.yml
+++ b/azure-templates/steps-post-build.yml
@@ -39,6 +39,7 @@ steps:
               -replace "{display_version}", "$(releaseVersion)" `
               -replace "{quarterly_display_version}", "$(quarterlyReleaseVersion)" `
               -replace "{labview_short_version}", "$(shortLvVersion)" `
+              -replace "{pkg_x86_bitness_suffix}", "$(nipkgx86suffix)" `
               -replace "{nipkgx64suffix}", "$(nipkgx64suffix)"
             Write-Output $contents
             Set-Content -Value $contents -Path "$(nipkgPath)\control\control"


### PR DESCRIPTION
- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-custom-device-build-tools/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

There is a missing item that needs to be replaced in the nipkg control files:  {pkg_x86_bitness_suffix}.  Currently if you try to install scripting/example nipkgs, they will be confused that this variable is not replaced.

### Why should this Pull Request be merged?

Fix packages to include the correct version prerequisites by replacing this suffix.

### What testing has been done?

![image](https://user-images.githubusercontent.com/42351034/225982624-8248c71c-ec3d-47d3-b243-9f0bd9db7a1a.png)