### PR TITLE
Add ".git" to end of Git URL in manifest file

### DIFF
--- a/azure-templates/steps-post-build.yml
+++ b/azure-templates/steps-post-build.yml
@@ -122,7 +122,7 @@ steps:
           $scmObject = [PSCustomObject]@{
             GIT_BRANCH = "$(sourceBranch)"
             GIT_COMMIT = "$(Build.SourceVersion)"
-            GIT_URL = "$(Build.Repository.Uri)"
+            GIT_URL = "$(Build.Repository.Uri).git"
           }
           $outputObject = [PSCustomObject]@{
             scm = $scmObject


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-custom-device-build-tools/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Add ".git" to end of Git URL in manifest file

### Why should this Pull Request be merged?

ATS is failing with message "Could not parse URL 'https://github.com/ni/niveristand-scan-engine-ethercat-custom-device'" after consuming the latest Scan Engine build with the manifest file creation. Comparing the new manifest to the old, we are leaving out a ".git" at the end of the URL.

### What testing has been done?

- Created a new release/23.3 branch of this repo to validate manifest.json output
- Hand-edited the manifest.json files for release branch builds of Scan Engine CD and Sync CD, then validated the resulting feed can clone the repos and run tests.
