### PR TITLE
change timeout to 120 minutes

### DIFF
--- a/azure-templates/stages.yml
+++ b/azure-templates/stages.yml
@@ -58,6 +58,7 @@ stages:
       - ${{ each lvVersionToBuild in parameters.lvVersionsToBuild }}:
         - job: Job${{ lvVersionToBuild.version }}_${{ lvVersionToBuild.bitness }}
           displayName: LabVIEW ${{ lvVersionToBuild.version }} ${{ parameters.lvVersionsToBuild.bitness }}
+          timeoutInMinutes: 120
           steps:
             - template: steps-pre-build.yml # Configure variables, check out repos, Clear cache
               parameters:


### PR DESCRIPTION
- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-custom-device-build-tools/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Changes the timeout in minutes to 120 to accomodate long build times for the PPLs in Comm Bus projects with LV 2020.

### Why should this Pull Request be merged?

Currently some of the custom devices are timing out occasionally.

### What testing has been done?

PR for this repo should continue to build successfully.