### PR TITLE
Add option for no build steps

### DIFF
--- a/azure-templates/stages.yml
+++ b/azure-templates/stages.yml
@@ -22,6 +22,7 @@ parameters:
   # buildSteps: list of {projectLocation, buildOperation, target, buildSpec}
   - name: buildSteps
     type: object
+    default: "None"
 
   # packages: list of {controlFileName, payloadMaps: list of {payloadLocation, installLocation} }
   - name: packages
@@ -67,12 +68,13 @@ stages:
                 buildOutputLocation:     ${{ parameters.buildOutputLocation }}
                 codegenVis:              ${{ parameters.codegenVis }}
 
-            - ${{ each buildStep in parameters.buildSteps }}:
-              - template: steps-build.yml # config file and build specs
-                parameters:
-                  buildStep:          ${{ buildStep }}
-                  dependencies:       ${{ parameters.dependencies }}
-                  lvVersionToBuild:   ${{ lvVersionToBuild }}
+            - ${{ if ne( buildSteps, "None" )}}:
+              - ${{ each buildStep in parameters.buildSteps }}:
+                  - template: steps-build.yml # config file and build specs
+                    parameters:
+                      buildStep:          ${{ buildStep }}
+                      dependencies:       ${{ parameters.dependencies }}
+                      lvVersionToBuild:   ${{ lvVersionToBuild }}
 
             - template: steps-post-build.yml # nipkg and archive
               parameters:

--- a/azure-templates/stages.yml
+++ b/azure-templates/stages.yml
@@ -22,7 +22,7 @@ parameters:
   # buildSteps: list of {projectLocation, buildOperation, target, buildSpec}
   - name: buildSteps
     type: object
-    default: 'None'
+    default: ''
 
   # packages: list of {controlFileName, payloadMaps: list of {payloadLocation, installLocation} }
   - name: packages

--- a/azure-templates/stages.yml
+++ b/azure-templates/stages.yml
@@ -68,7 +68,7 @@ stages:
                 buildOutputLocation:     ${{ parameters.buildOutputLocation }}
                 codegenVis:              ${{ parameters.codegenVis }}
 
-            - ${{ if ne( buildSteps, "None" )}}:
+            - ${{ if ne( parameters.buildSteps, "None" )}}:
               - ${{ each buildStep in parameters.buildSteps }}:
                   - template: steps-build.yml # config file and build specs
                     parameters:

--- a/azure-templates/stages.yml
+++ b/azure-templates/stages.yml
@@ -68,7 +68,7 @@ stages:
                 buildOutputLocation:     ${{ parameters.buildOutputLocation }}
                 codegenVis:              ${{ parameters.codegenVis }}
 
-            - ${{ if ne( parameters.buildSteps, 'None' )}}:
+            - ${{ if ne( parameters.buildSteps, '' )}}:
               - ${{ each buildStep in parameters.buildSteps }}:
                   - template: steps-build.yml # config file and build specs
                     parameters:

--- a/azure-templates/stages.yml
+++ b/azure-templates/stages.yml
@@ -22,7 +22,7 @@ parameters:
   # buildSteps: list of {projectLocation, buildOperation, target, buildSpec}
   - name: buildSteps
     type: object
-    default: "None"
+    default: 'None'
 
   # packages: list of {controlFileName, payloadMaps: list of {payloadLocation, installLocation} }
   - name: packages
@@ -68,7 +68,7 @@ stages:
                 buildOutputLocation:     ${{ parameters.buildOutputLocation }}
                 codegenVis:              ${{ parameters.codegenVis }}
 
-            - ${{ if ne( parameters.buildSteps, "None" )}}:
+            - ${{ if ne( parameters.buildSteps, 'None' )}}:
               - ${{ each buildStep in parameters.buildSteps }}:
                   - template: steps-build.yml # config file and build specs
                     parameters:


### PR DESCRIPTION
- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-custom-device-build-tools/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Allows build steps to not be specified, to allow a custom device (custom-device-wizard) to build with no build steps

### Why should this Pull Request be merged?

Right now custom-device-wizard can't be built because buildSteps is required

### What testing has been done?

Normal builds continue to work (can't test custom-device-wizard until this is submitted into main because azure pipelines won't let you choose a custom resource unless the base yaml can be compiled).