### PR TITLE
Add optional parameter to define a custom project location

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -66,7 +66,7 @@ stages:
             - version: '2023'
               bitness: '32bit'
 
-        - projectLocation: '%cd%\niveristand-custom-device-build-tools\test-build\Source\IndividualBuildSpecs.lvproj'
+        - projectLocation: '$(workspaceDirectory)\niveristand-custom-device-build-tools\test-build\Source\IndividualBuildSpecs.lvproj'
           buildOperation: 'ExecuteBuildSpec'
           target: 'Linux x64'
           buildSpec: 'BuildSpecSameName'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -66,10 +66,11 @@ stages:
             - version: '2023'
               bitness: '32bit'
 
-        - projectLocation: 'test-build\Source\IndividualBuildSpecs.lvproj'
+        - projectLocation: '%cd%\niveristand-custom-device-build-tools\test-build\Source\IndividualBuildSpecs.lvproj'
           buildOperation: 'ExecuteBuildSpec'
           target: 'Linux x64'
           buildSpec: 'BuildSpecSameName'
+          projectOverride: 'Absolute'
 
         - projectLocation: 'test-build\Source\IndividualBuildSpecs.lvproj'
           buildOperation: 'ExecuteBuildSpec'

--- a/azure-templates/steps-build.yml
+++ b/azure-templates/steps-build.yml
@@ -169,14 +169,13 @@ steps:
     displayName: Build ${{ parameters.buildStep.buildSpec }} on ${{ parameters.buildStep.target }} in ${{ parameters.buildStep.projectLocation }}
     inputs:
       script: |
-        echo on
-        REM if "${{ parameters.buildStep.projectOverride}}"=="Absolute" (
-        REM  set project_path = "${{ parameters.buildStep.projectLocation }}"
-        REM ) else (
-          set custom_project_path = "%cd%\$(customDeviceRepoName)\${{ parameters.buildStep.projectLocation }}"
-        REM )
-        echo "using %custom_project_path%"
-        if not '$(skipBuildStep)'=='True' (
+        ECHO on
+        IF "${{ parameters.buildStep.projectOverride}}"=="Absolute" (
+          SET project_path="${{ parameters.buildStep.projectLocation }}"
+        ) ELSE (
+          SET project_path="%cd%\$(customDeviceRepoName)\${{ parameters.buildStep.projectLocation }}"
+        )
+        IF NOT '$(skipBuildStep)'=='True' (
           $(lvCLICall) ^
             -OperationName "${{ parameters.buildStep.buildOperation }}" ^
             -ProjectPath "%custom_project_path%" ^

--- a/azure-templates/steps-build.yml
+++ b/azure-templates/steps-build.yml
@@ -24,7 +24,7 @@ steps:
         }
         Else
         {
-          $lvConfigFilePath = "$PWD\$(customDeviceRepoName)\${{ parameters.buildStep.projectLocation }}.config"
+          $lvConfigFilePath = "$(workspaceDirectory)\$(customDeviceRepoName)\${{ parameters.buildStep.projectLocation }}.config"
         }
         If (-not(Test-Path -Path $lvConfigFilePath))
         {
@@ -144,17 +144,17 @@ steps:
               }
               `
               Write-Output "Copying dependency ${{ dependency.file }}..."
-              If (-not(Test-Path -Path "$PWD\$(customDeviceRepoName)\${{ dependency.destination }}"))
+              If (-not(Test-Path -Path "$(workspaceDirectory)\$(customDeviceRepoName)\${{ dependency.destination }}"))
               {
                 New-Item `
-                  -Path "$PWD\$(customDeviceRepoName)\${{ dependency.destination }}" `
+                  -Path "$(workspaceDirectory)\$(customDeviceRepoName)\${{ dependency.destination }}" `
                   -ItemType 'Directory'
               }
               If (Test-Path $dependencyFilePath)
               {
                 Copy-Item `
                   -Path $dependencyFilePath `
-                  -Destination "$PWD\$(customDeviceRepoName)\${{ dependency.destination }}\" `
+                  -Destination "$(workspaceDirectory)\$(customDeviceRepoName)\${{ dependency.destination }}\" `
                   -Recurse `
                   -Force
               }
@@ -180,7 +180,7 @@ steps:
         IF "${{ parameters.buildStep.projectOverride}}"=="Absolute" (
           SET project_path="${{ parameters.buildStep.projectLocation }}"
         ) ELSE (
-          SET project_path="%cd%\$(customDeviceRepoName)\${{ parameters.buildStep.projectLocation }}"
+          SET project_path="$(workspaceDirectory)\$(customDeviceRepoName)\${{ parameters.buildStep.projectLocation }}"
         )
         IF NOT '$(skipBuildStep)'=='True' (
           $(lvCLICall) ^
@@ -188,7 +188,7 @@ steps:
             -ProjectPath "%project_path%" ^
             $(targetArgument) ^
             $(buildSpecArgument) ^
-            -LogFilePath "%cd%\$(customDeviceRepoName)\lvBuildSpecs.log"
+            -LogFilePath "$(workspaceDirectory)\$(customDeviceRepoName)\lvBuildSpecs.log"
         )
 
   - task: CmdLine@2

--- a/azure-templates/steps-build.yml
+++ b/azure-templates/steps-build.yml
@@ -170,11 +170,11 @@ steps:
     inputs:
       script: |
         echo on
-        if "${{ parameters.buildStep.projectOverride}}"=="Absolute" (
-          set project_path = "${{ parameters.buildStep.projectLocation }}"
-        ) else (
+        REM if "${{ parameters.buildStep.projectOverride}}"=="Absolute" (
+        REM  set project_path = "${{ parameters.buildStep.projectLocation }}"
+        REM ) else (
           set project_path = "%cd%\$(customDeviceRepoName)\${{ parameters.buildStep.projectLocation }}"
-        )
+        REM )
         echo "using %project_path%"
         if not '$(skipBuildStep)'=='True' (
           $(lvCLICall) ^

--- a/azure-templates/steps-build.yml
+++ b/azure-templates/steps-build.yml
@@ -18,10 +18,17 @@ steps:
       targetType: 'inline'
       failOnStdErr: true
       script: |
-        If (-not(Test-Path -Path "$(customDeviceRepoName)\${{ parameters.buildStep.projectLocation }}.config"))
+        If ("${{ parameters.buildStep.projectOverride }}" -eq "Absolute")
+        {
+          $lvConfigFilePath = "${{ parameters.buildStep.projectLocation }}.config"
+        }
+        Else
+        {
+          $lvConfigFilePath = "$PWD\$(customDeviceRepoName)\${{ parameters.buildStep.projectLocation }}.config"
+        }
+        If (-not(Test-Path -Path $projectConfigPath))
         {
           Write-Output "adding .config file to project..."
-          $lvConfigFilePath = '$(customDeviceRepoName)\${{ parameters.buildStep.projectLocation }}.config'
           Copy-Item "$(buildTools)\resources\LabVIEW.exe.config" -Destination $lvConfigFilePath
           (Get-Content -Path $lvConfigFilePath) -replace '2016.0.0.0', '$(lvConfigVersion)' | Set-Content -Path $lvConfigFilePath
         }
@@ -137,17 +144,17 @@ steps:
               }
               `
               Write-Output "Copying dependency ${{ dependency.file }}..."
-              If (-not(Test-Path -Path '$(customDeviceRepoName)\${{ dependency.destination }}'))
+              If (-not(Test-Path -Path '$PWD\$(customDeviceRepoName)\${{ dependency.destination }}'))
               {
                 New-Item `
-                  -Path '$(customDeviceRepoName)\${{ dependency.destination }}' `
+                  -Path '$PWD\$(customDeviceRepoName)\${{ dependency.destination }}' `
                   -ItemType 'Directory'
               }
               If (Test-Path $dependencyFilePath)
               {
                 Copy-Item `
                   -Path $dependencyFilePath `
-                  -Destination '$(customDeviceRepoName)\${{ dependency.destination }}\' `
+                  -Destination '$PWD\$(customDeviceRepoName)\${{ dependency.destination }}\' `
                   -Recurse `
                   -Force
               }

--- a/azure-templates/steps-build.yml
+++ b/azure-templates/steps-build.yml
@@ -175,6 +175,7 @@ steps:
         ) else (
           set project_path = "%cd%\$(customDeviceRepoName)\${{ parameters.buildStep.projectLocation }}"
         )
+        echo "using %project_path%"
         if not '$(skipBuildStep)'=='True' (
           $(lvCLICall) ^
             -OperationName "${{ parameters.buildStep.buildOperation }}" ^

--- a/azure-templates/steps-build.yml
+++ b/azure-templates/steps-build.yml
@@ -173,13 +173,13 @@ steps:
         REM if "${{ parameters.buildStep.projectOverride}}"=="Absolute" (
         REM  set project_path = "${{ parameters.buildStep.projectLocation }}"
         REM ) else (
-          set project_path = "%cd%\$(customDeviceRepoName)\${{ parameters.buildStep.projectLocation }}"
+          set custom_project_path = "%cd%\$(customDeviceRepoName)\${{ parameters.buildStep.projectLocation }}"
         REM )
-        echo "using %project_path%"
+        echo "using %custom_project_path%"
         if not '$(skipBuildStep)'=='True' (
           $(lvCLICall) ^
             -OperationName "${{ parameters.buildStep.buildOperation }}" ^
-            -ProjectPath "%project_path%" ^
+            -ProjectPath "%custom_project_path%" ^
             $(targetArgument) ^
             $(buildSpecArgument) ^
             -LogFilePath "%cd%\$(customDeviceRepoName)\lvBuildSpecs.log"

--- a/azure-templates/steps-build.yml
+++ b/azure-templates/steps-build.yml
@@ -26,7 +26,7 @@ steps:
         {
           $lvConfigFilePath = "$PWD\$(customDeviceRepoName)\${{ parameters.buildStep.projectLocation }}.config"
         }
-        If (-not(Test-Path -Path $projectConfigPath))
+        If (-not(Test-Path -Path $lvConfigFilePath))
         {
           Write-Output "adding .config file to project..."
           Copy-Item "$(buildTools)\resources\LabVIEW.exe.config" -Destination $lvConfigFilePath

--- a/azure-templates/steps-build.yml
+++ b/azure-templates/steps-build.yml
@@ -178,7 +178,7 @@ steps:
         IF NOT '$(skipBuildStep)'=='True' (
           $(lvCLICall) ^
             -OperationName "${{ parameters.buildStep.buildOperation }}" ^
-            -ProjectPath "%custom_project_path%" ^
+            -ProjectPath "%project_path%" ^
             $(targetArgument) ^
             $(buildSpecArgument) ^
             -LogFilePath "%cd%\$(customDeviceRepoName)\lvBuildSpecs.log"

--- a/azure-templates/steps-build.yml
+++ b/azure-templates/steps-build.yml
@@ -170,12 +170,19 @@ steps:
     inputs:
       script: |
         echo on
-        if not '$(skipBuildStep)'=='True' $(lvCLICall) ^
-          -OperationName "${{ parameters.buildStep.buildOperation }}" ^
-          -ProjectPath "%cd%\$(customDeviceRepoName)\${{ parameters.buildStep.projectLocation }}" ^
-          $(targetArgument) ^
-          $(buildSpecArgument) ^
-          -LogFilePath "%cd%\$(customDeviceRepoName)\lvBuildSpecs.log"
+        if "${{ parameters.buildStep.projectOverride}}"=="Absolute" (
+          set project_path = "${{ parameters.buildStep.projectLocation }}"
+        ) else (
+          set project_path = "%cd%\$(customDeviceRepoName)\${{ parameters.buildStep.projectLocation }}"
+        )
+        if not '$(skipBuildStep)'=='True' (
+          $(lvCLICall) ^
+            -OperationName "${{ parameters.buildStep.buildOperation }}" ^
+            -ProjectPath "%project_path%" ^
+            $(targetArgument) ^
+            $(buildSpecArgument) ^
+            -LogFilePath "%cd%\$(customDeviceRepoName)\lvBuildSpecs.log"
+        )
 
   - task: CmdLine@2
     displayName: Close LabVIEW

--- a/azure-templates/steps-build.yml
+++ b/azure-templates/steps-build.yml
@@ -144,17 +144,17 @@ steps:
               }
               `
               Write-Output "Copying dependency ${{ dependency.file }}..."
-              If (-not(Test-Path -Path '$PWD\$(customDeviceRepoName)\${{ dependency.destination }}'))
+              If (-not(Test-Path -Path "$PWD\$(customDeviceRepoName)\${{ dependency.destination }}"))
               {
                 New-Item `
-                  -Path '$PWD\$(customDeviceRepoName)\${{ dependency.destination }}' `
+                  -Path "$PWD\$(customDeviceRepoName)\${{ dependency.destination }}" `
                   -ItemType 'Directory'
               }
               If (Test-Path $dependencyFilePath)
               {
                 Copy-Item `
                   -Path $dependencyFilePath `
-                  -Destination '$PWD\$(customDeviceRepoName)\${{ dependency.destination }}\' `
+                  -Destination "$PWD\$(customDeviceRepoName)\${{ dependency.destination }}\" `
                   -Recurse `
                   -Force
               }

--- a/azure-templates/steps-pre-build.yml
+++ b/azure-templates/steps-pre-build.yml
@@ -24,6 +24,7 @@ steps:
       script: |
         Write-Output "Defining repository variables..."
         Write-Host '##vso[task.setvariable variable=buildTools]niveristand-custom-device-build-tools'
+        Write-Host "##vso[task.setvariable variable=workspaceDirectory]$PWD"
         If ('$(Build.Reason)' -eq 'PullRequest')
         {
           Write-Output "Setting variables for Pull Requests..."
@@ -128,8 +129,8 @@ steps:
         echo on
         $(lvCLICall) ^
           -OperationName "SecureRunVI" ^
-          -VIPath "%cd%\$(buildTools)\lv\operations\Utilities\ClearCache.vi" ^
-          -LogFilePath "%cd%\$(customDeviceRepoName)\lvClearCache.log"
+          -VIPath "$(workspaceDirectory)\$(buildTools)\lv\operations\Utilities\ClearCache.vi" ^
+          -LogFilePath "$(workspaceDirectory)\$(customDeviceRepoName)\lvClearCache.log"
 
   - ${{ each codegenVi in parameters.codegenVis }}:
     - ${{ if ne(codegenVi, '' )}}:
@@ -140,5 +141,5 @@ steps:
             echo on
             $(lvCLICall) ^
               -OperationName "SecureRunVI" ^
-              -VIPath "%cd%\$(customDeviceRepoName)\${{ codegenVi }}" ^
-              -LogFilePath "%cd%\$(customDeviceRepoName)\lvCodegen.log"
+              -VIPath "$(workspaceDirectory)\$(customDeviceRepoName)\${{ codegenVi }}" ^
+              -LogFilePath "$(workspaceDirectory)\$(customDeviceRepoName)\lvCodegen.log"


### PR DESCRIPTION
- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-custom-device-build-tools/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

* creates a new variable called workspaceDirectory that works like $PWD or %cd% to ensure paths are absolute and avoid any relative path errors
* Adds an optional parameter under a buildStep called projectOverride that will use the projectLocation as an absolute path if the projectOverride value is set to "Absolute", instead of a relative path inside of the repo.

### Why should this Pull Request be merged?

an absolute path is needed for some internal tools used in building ADAS Toolkit custom device.

### What testing has been done?

One of the build steps in azure-pipelines.yml now uses an absolute project path to test this behavior.  The PR build should only pass if it's working as desired.