### PR TITLE
norebuild

### DIFF
--- a/azure-templates/steps-pre-build.yml
+++ b/azure-templates/steps-pre-build.yml
@@ -40,7 +40,7 @@ steps:
         If (Test-Path -Path "${{ parameters.archiveLocation }}\NI\export\$sourceBranch\norebuild")
         {
           Write-Output "norebuild found in this source branch, so skipping this build..."
-          Exit 0
+          Exit 1
         }
         Write-Output "Using $sourceBranch in archive path..."
         Write-Host "##vso[task.setvariable variable=sourceBranch]$sourceBranch"


### PR DESCRIPTION
- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-custom-device-build-tools/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Adds a norebuild check to the build-tools at the start of a build.

### Why should this Pull Request be merged?

this will protect releases from building after being made final.

### What testing has been done?

no norebuild case will be tested with the PR build.

When norebuild is included, builds will fail with a message about the reason:
![image](https://user-images.githubusercontent.com/42351034/231332473-89454eba-bd41-4522-bcc4-67109a5dfc42.png)