### PR TITLE
Quarterly Release removed

### DIFF
--- a/azure-templates/stages.yml
+++ b/azure-templates/stages.yml
@@ -42,9 +42,7 @@ parameters:
   # strings (releaseVersion, quarterlyReleaseVersion, buildOutputLocation, archiveLocation)
   - name: releaseVersion
     type: string
-  - name: quarterlyReleaseVersion
-    type: string
-    default: 1999
+    default: 0.0.0
   - name: buildOutputLocation
     type: string
   - name: archiveLocation

--- a/azure-templates/stages.yml
+++ b/azure-templates/stages.yml
@@ -42,7 +42,6 @@ parameters:
   # strings (releaseVersion, quarterlyReleaseVersion, buildOutputLocation, archiveLocation)
   - name: releaseVersion
     type: string
-    default: 0.0.0
   - name: buildOutputLocation
     type: string
   - name: archiveLocation


### PR DESCRIPTION
- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-custom-device-build-tools/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

removes an unused paramter with a default.

### Why should this Pull Request be merged?

This was originally left in to keep builds from failing while it is being removed, now all builds have had this removed.

### What testing has been done?

Looked through the custom devices to make sure quarterlyReleaseVersion has been removed.
