### PR TITLE
Fail on missed dependency

### DIFF
--- a/azure-templates/steps-build.yml
+++ b/azure-templates/steps-build.yml
@@ -138,8 +138,7 @@ steps:
               }
               If (-not $dependencyFilePath)
               {
-                Write-Output "no successful build of dependency ${{ dependency.file }} was found at ${{ dependency.source }}."
-                Write-Output "SKIPPING DEPENDENCY, END STEP..."
+                Write-Error "no successful build of dependency ${{ dependency.file }} was found at ${{ dependency.source }}."
                 break
               }
               `


### PR DESCRIPTION
- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-custom-device-build-tools/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Errors if the dependency requested has no successful builds.

### Why should this Pull Request be merged?

If a dependency is missing due to a mistake in the yml or a lack of build artifacts, it is better to throw the error in the dependencies step to make it clear that this is the issue, rather than more convoluted errors in the build steps themselves that may or may not communicate information about the missing dependency.

### What testing has been done?

Ran this pipeline with missing dependency files:
![image](https://user-images.githubusercontent.com/42351034/232099054-7a58bb47-15c8-4ccc-85c9-bdb1377cfbcf.png)