### PR TITLE
Move build steps inline powershell scripts to files

### DIFF
--- a/azure-templates/powershell-scripts/build-step-setup.ps1
+++ b/azure-templates/powershell-scripts/build-step-setup.ps1
@@ -1,0 +1,54 @@
+param(
+    [string]$projectOverride,
+    [string]$projectPath,
+    [string]$buildOperation,
+    [string]$buildSpec,
+    [string]$target
+)
+
+If ("$projectOverride" -eq "Absolute")
+{
+    Write-Host "##vso[task.setvariable variable=CD.AbsolutePath]True"
+    $lvConfigFilePath = "$projectPath.config"
+}
+Else
+{
+    Write-Host "##vso[task.setvariable variable=CD.AbsolutePath]False"
+    $lvConfigFilePath = "$env:CD_WORKSPACE\$env:CD_REPOSITORY\$projectPath.config"
+}
+
+If (-not(Test-Path -Path $lvConfigFilePath))
+{
+    Write-Output "adding .config file to project..."
+    Copy-Item "$env:CD_BUILDTOOLS\resources\LabVIEW.exe.config" -Destination $lvConfigFilePath
+    (Get-Content -Path $lvConfigFilePath) -replace "2016.0.0.0", "$env:CD_LABVIEW_CONFIG)" | Set-Content -Path $lvConfigFilePath
+}
+`
+If ("$buildOperation" -eq "ExecuteAllBuildSpecs")
+{
+    Write-Output "Configuring build operation for all targets and build specs..."
+    Write-Host "##vso[task.setvariable variable=CD.TargetArg]"
+    Write-Host "##vso[task.setvariable variable=CD.BuildSpecArg]"
+}
+Elseif ("$buildOperation" -eq "ExecuteBuildSpecAllTargets")
+{
+    Write-Output "Configuring build operation for all targets and single build spec..."
+    Write-Host "##vso[task.setvariable variable=CD.TargetArg]"
+    Write-Host "##vso[task.setvariable variable=CD.BuildSpecArg]-BuildSpecName `"$buildSpec`" "
+}
+Elseif ("$buildOperation" -eq "ExecuteBuildSpec")
+{
+    Write-Output "Configuring build operation for specific target and build spec..."
+    Write-Host "##vso[task.setvariable variable=CD.TargetArg]-TargetName `"$target`" "
+    Write-Host "##vso[task.setvariable variable=CD.BuildSpecArg]-BuildSpecName `"$buildSpec`" "
+    Write-Host "##vso[task.setvariable variable=CD.BuildTarget]$target"
+}
+Else
+{
+    Write-Error "invalid buildStep.buildOperation provided.  Valid options are ExecuteBuildSpec, ExecuteBuildSpecAllTargets, and ExecuteAllBuildSpecs."
+}
+`
+Write-Output "resetting build exclusion skip variable..."
+Write-Host "##vso[task.setvariable variable=CD.SkipThisStep]False"
+Write-Host "##vso[task.setvariable variable=CD.ProjectPath]$projectPath"
+Write-Host "##vso[task.setvariable variable=CD.BuildOperation]$buildOperation"

--- a/azure-templates/powershell-scripts/build-step-setup.ps1
+++ b/azure-templates/powershell-scripts/build-step-setup.ps1
@@ -1,5 +1,5 @@
 param(
-    [string]$projectOverride,
+    [string]$projectOverride = "No Overrides",
     [string]$projectPath,
     [string]$buildOperation,
     [string]$buildSpec,

--- a/azure-templates/powershell-scripts/dependency-setup.ps1
+++ b/azure-templates/powershell-scripts/dependency-setup.ps1
@@ -1,0 +1,91 @@
+param(
+    [string]$source,
+    [string]$file,
+    [string]$destination
+)
+
+If ("$env:CD_SKIPTHISSTEP" -eq "True")
+{
+    Write-Output "dependency copying was skipped because a matching exclusion was found for this build step."
+}
+Else
+{
+  Write-Output "Configuring target directory environment..."
+  If ("$env:CD_BUILDTARGET" -eq "My Computer")
+  {
+    $targetName = "Windows"
+  }
+  Elseif ("$env:CD_BUILDTARGET" -eq "Linux x64")
+  {
+    $targetName = "Linux_x64"
+  }
+  Write-Output "Setting dependency environment to $targetName"
+  
+  $branchName = "main"
+  If ("$env:CD_SOURCEBRANCH" -ne "$branchName")
+  {
+    Write-Output "Checking for builds of `"$env:CD_SOURCEBRANCH`" branch..."
+    If (Test-Path -Path "$source\NI\export\$env:CD_SOURCEBRANCH\*\$env:CD_LABVIEW_VERSION\$env:CD_ARCHITECTURE")
+    {
+      Write-Output "branch was found, using $env:CD_SOURCEBRANCH instead of $branchName..."
+      $branchName = "$env:CD_SOURCEBRANCH"
+    }
+    Else
+    {
+      Write-Output "branch not found, using a build of `"$branchName`"..."
+    }
+  }
+  Else
+  {
+    Write-Output "Using `"$branchName`" branch..."
+  }
+  `
+  Write-Output "Finding latest successful build of dependency `"$file`"..."
+  $allDependencyBuilds = Get-ChildItem `
+    -Path "$source\NI\export\$branchName\*" `
+    | Sort-Object {$_.Name} -Descending
+  Foreach ($build in $allDependencyBuilds)
+  {
+    Write-Output "Checking $build..."
+    If (Test-Path -Path "$build\$env:CD_LABVIEW_VERSION\$env:CD_ARCHITECTURE\")
+    {
+      Write-Output "Checking for .finished file..."
+      If (Test-Path -Path "$build\.finished")
+      {
+        Write-Output "latest successful build: $build"
+        $dependencyFilePath = "$build\$env:CD_LABVIEW_VERSION\$env:CD_ARCHITECTURE\$file"
+        Break
+      }
+      Else
+      {
+        Write-Output ".finished file not found at $build"
+      }
+    }
+  }
+  If (-not $dependencyFilePath)
+  {
+    Write-Error "no successful build of dependency $file was found at $source."
+    break
+  }
+  `
+  Write-Output "Copying dependency $file..."
+  If (-not(Test-Path -Path "$env:CD_WORKSPACE\$env:CD_REPOSITORY\$destination"))
+  {
+    New-Item `
+      -Path "$env:CD_WORKSPACE\$env:CD_REPOSITORY\$destination" `
+      -ItemType 'Directory'
+  }
+  If (Test-Path $dependencyFilePath)
+  {
+    Copy-Item `
+      -Path $dependencyFilePath `
+      -Destination "$env:CD_WORKSPACE\$env:CD_REPOSITORY\$destination\" `
+      -Recurse `
+      -Force
+  }
+  Else
+  {
+    Write-Output "Dependency does not exist at $dependencyFilePath..."
+    Write-Output "SKIPPING DEPENDENCY, END STEP..."
+  }
+}

--- a/azure-templates/powershell-scripts/dependency-setup.ps1
+++ b/azure-templates/powershell-scripts/dependency-setup.ps1
@@ -14,12 +14,12 @@ Else
   If ("$env:CD_BUILDTARGET" -eq "My Computer")
   {
     $file = $file -replace '$target', "Windows"
-    Write-Output "Setting dependency environment `$target to `"Windows`""
+    Write-Output "Setting dependency environment `$target to `"Windows`" - new dependency path is $file..."
   }
   Elseif ("$env:CD_BUILDTARGET" -eq "Linux x64")
   {
     $file = $file -replace '$target', "Linux_x64"
-    Write-Output "Setting dependency environment `$target to `"Linux_x64`""
+    Write-Output "Setting dependency environment `$target to `"Linux_x64`" - new dependency path is $file..."
   }
   
   $branchName = "main"

--- a/azure-templates/powershell-scripts/dependency-setup.ps1
+++ b/azure-templates/powershell-scripts/dependency-setup.ps1
@@ -13,12 +13,12 @@ Else
   Write-Output "Configuring target directory environment..."
   If ("$env:CD_BUILDTARGET" -eq "My Computer")
   {
-    $file = $file -replace '$target', "Windows"
+    $file = $file -replace '\$target', "Windows"
     Write-Output "Setting dependency environment `$target to `"Windows`" - new dependency path is $file..."
   }
   Elseif ("$env:CD_BUILDTARGET" -eq "Linux x64")
   {
-    $file = $file -replace '$target', "Linux_x64"
+    $file = $file -replace '\$target', "Linux_x64"
     Write-Output "Setting dependency environment `$target to `"Linux_x64`" - new dependency path is $file..."
   }
   

--- a/azure-templates/powershell-scripts/dependency-setup.ps1
+++ b/azure-templates/powershell-scripts/dependency-setup.ps1
@@ -13,13 +13,13 @@ Else
   Write-Output "Configuring target directory environment..."
   If ("$env:CD_BUILDTARGET" -eq "My Computer")
   {
-    $targetName = "Windows"
+    $target = "Windows" # This variable is used in azure-pipelines.yml files
   }
   Elseif ("$env:CD_BUILDTARGET" -eq "Linux x64")
   {
-    $targetName = "Linux_x64"
+    $target = "Linux_x64" # This variable is used in azure-pipelines.yml files
   }
-  Write-Output "Setting dependency environment to $targetName"
+  Write-Output "Setting dependency environment `$target to `"$target`""
   
   $branchName = "main"
   If ("$env:CD_SOURCEBRANCH" -ne "$branchName")

--- a/azure-templates/powershell-scripts/dependency-setup.ps1
+++ b/azure-templates/powershell-scripts/dependency-setup.ps1
@@ -13,13 +13,14 @@ Else
   Write-Output "Configuring target directory environment..."
   If ("$env:CD_BUILDTARGET" -eq "My Computer")
   {
-    $target = "Windows" # This variable is used in azure-pipelines.yml files
+    $file = $file -replace '$target', "Windows"
+    Write-Output "Setting dependency environment `$target to `"Windows`""
   }
   Elseif ("$env:CD_BUILDTARGET" -eq "Linux x64")
   {
-    $target = "Linux_x64" # This variable is used in azure-pipelines.yml files
+    $file = $file -replace '$target', "Linux_x64"
+    Write-Output "Setting dependency environment `$target to `"Linux_x64`""
   }
-  Write-Output "Setting dependency environment `$target to `"$target`""
   
   $branchName = "main"
   If ("$env:CD_SOURCEBRANCH" -ne "$branchName")
@@ -39,7 +40,6 @@ Else
   {
     Write-Output "Using `"$branchName`" branch..."
   }
-  `
   Write-Output "Finding latest successful build of dependency `"$file`"..."
   $allDependencyBuilds = Get-ChildItem `
     -Path "$source\NI\export\$branchName\*" `

--- a/azure-templates/powershell-scripts/dependency-setup.ps1
+++ b/azure-templates/powershell-scripts/dependency-setup.ps1
@@ -85,7 +85,6 @@ Else
   }
   Else
   {
-    Write-Output "Dependency does not exist at $dependencyFilePath..."
-    Write-Output "SKIPPING DEPENDENCY, END STEP..."
+    Write-Error "Dependency does not exist at $dependencyFilePath."
   }
 }

--- a/azure-templates/powershell-scripts/dependency-setup.ps1
+++ b/azure-templates/powershell-scripts/dependency-setup.ps1
@@ -79,7 +79,7 @@ Else
   {
     Copy-Item `
       -Path $dependencyFilePath `
-      -Destination "$env:CD_WORKSPACE\$env:CD_REPOSITORY\$destination\" `
+      -Destination "$env:CD_WORKSPACE\$env:CD_REPOSITORY\$destination" `
       -Recurse `
       -Force
   }

--- a/azure-templates/steps-build.yml
+++ b/azure-templates/steps-build.yml
@@ -62,12 +62,12 @@ steps:
     inputs:
       script: |
         ECHO ON
-        IF '$(CD.AbsolutePath)' (
-          SET project_path="$(CD.ProjectPath)"
-        ) ELSE (
+        IF '$(CD.AbsolutePath)'=='True' (
           SET project_path="$(CD.Workspace)\$(CD.Repository)\$(CD.ProjectPath)"
+        ) ELSE (
+          SET project_path="$(CD.ProjectPath)"
         )
-        IF NOT '$(CD.SkipThisStep)' (
+        IF '$(CD.SkipThisStep)'=='False' (
           $(CD.LabVIEWCLI) ^
             -OperationName "$(CD.BuildOperation)" ^
             -ProjectPath %project_path% ^
@@ -80,4 +80,4 @@ steps:
     displayName: Close LabVIEW
     condition: always() # close LabVIEW even if previous steps failed
     inputs:
-      script: IF NOT '$(CD.SkipThisStep)' (taskkill /im labview.exe /f)
+      script: IF '$(CD.SkipThisStep)'=='False' (taskkill /im labview.exe /f)

--- a/azure-templates/steps-build.yml
+++ b/azure-templates/steps-build.yml
@@ -20,10 +20,10 @@ steps:
       failOnStdErr: True
       arguments: >
         -projectOverride "${{ parameters.buildStep.projectOverride }}"
-        -projectPath     ${{ parameters.buildStep.projectLocation }}
-        -buildOperation  ${{ parameters.buildStep.buildOperation }}
-        -buildSpec       ${{ parameters.buildStep.buildSpec }}
-        -target          ${{ parameters.buildStep.target }}
+        -projectPath     "${{ parameters.buildStep.projectLocation }}"
+        -buildOperation  "${{ parameters.buildStep.buildOperation }}"
+        -buildSpec       "${{ parameters.buildStep.buildSpec }}"
+        -target          "${{ parameters.buildStep.target }}"
 
   - ${{ each exclusion in parameters.buildStep.exclusions }}:
     - ${{ if and( eq(exclusion.version, parameters.lvVersionToBuild.version), eq(exclusion.bitness, parameters.lvVersionToBuild.bitness)) }}:
@@ -45,9 +45,9 @@ steps:
           filePath: 'niveristand-custom-device-build-tools/azure-templates/powershell-scripts/dependency-setup.ps1'
           failOnStdErr: true
           arguments: >
-            -source      ${{ dependency.source }}
-            -file        ${{ dependency.file }}
-            -destination ${{ dependency.destination }}
+            -source      "${{ dependency.source }}"
+            -file        "${{ dependency.file }}"
+            -destination "${{ dependency.destination }}"
 
     - ${{ if and( ne( dependency.file, '' ), ne( parameters.buildStep.buildOperation, 'ExecuteBuildSpec' ))}}:
       - task: PowerShell@2

--- a/azure-templates/steps-build.yml
+++ b/azure-templates/steps-build.yml
@@ -7,7 +7,7 @@ parameters:
   - name: lvVersionToBuild
     type: object
 
-# Note: the following variables are defined in pre-job-steps.yml:
+# Note: the following variables are defined in steps-prepare.yml:
   # CD.LabVIEW.Version, CD.Architecture, CD.Repository, CD.LabVIEW.Config,
   # CD.BuildTools, CD.LabVIEWCLI
 
@@ -15,49 +15,15 @@ steps:
   - task: PowerShell@2
     displayName: Prepare to build ${{ parameters.buildStep.buildSpec }} on ${{ parameters.buildStep.target }} in ${{ parameters.buildStep.projectLocation }}
     inputs:
-      targetType: 'inline'
-      failOnStdErr: true
-      script: |
-        If ("${{ parameters.buildStep.projectOverride }}" -eq "Absolute")
-        {
-          $lvConfigFilePath = "${{ parameters.buildStep.projectLocation }}.config"
-        }
-        Else
-        {
-          $lvConfigFilePath = "$(CD.Workspace)\$(CD.Repository)\${{ parameters.buildStep.projectLocation }}.config"
-        }
-        If (-not(Test-Path -Path $lvConfigFilePath))
-        {
-          Write-Output "adding .config file to project..."
-          Copy-Item "$(CD.BuildTools)\resources\LabVIEW.exe.config" -Destination $lvConfigFilePath
-          (Get-Content -Path $lvConfigFilePath) -replace '2016.0.0.0', '$(CD.LabVIEW.Config)' | Set-Content -Path $lvConfigFilePath
-        }
-        `
-        If ('${{ parameters.buildStep.buildOperation }}' -eq 'ExecuteAllBuildSpecs')
-        {
-          Write-Output "Configuring build operation for all targets and build specs..."
-          Write-Host '##vso[task.setvariable variable=targetArgument]'
-          Write-Host '##vso[task.setvariable variable=buildSpecArgument]'
-        }
-        Elseif ('${{ parameters.buildStep.buildOperation }}' -eq 'ExecuteBuildSpecAllTargets')
-        {
-          Write-Output "Configuring build operation for all targets and single build spec..."
-          Write-Host '##vso[task.setvariable variable=targetArgument]'
-          Write-Host '##vso[task.setvariable variable=buildSpecArgument]-BuildSpecName "${{ parameters.buildStep.buildSpec }}" '
-        }
-        Elseif ('${{ parameters.buildStep.buildOperation }}' -eq 'ExecuteBuildSpec')
-        {
-          Write-Output "Configuring build operation for specific target and build spec..."
-          Write-Host '##vso[task.setvariable variable=targetArgument]-TargetName "${{ parameters.buildStep.target }}" '
-          Write-Host '##vso[task.setvariable variable=buildSpecArgument]-BuildSpecName "${{ parameters.buildStep.buildSpec }}" '
-        }
-        Else
-        {
-          Write-Error "invalid buildStep.buildOperation provided.  Valid options are ExecuteBuildSpec, ExecuteBuildSpecAllTargets, and ExecuteAllBuildSpecs."
-        }
-        `
-        Write-Output "resetting build exclusion skip variable..."
-        Write-Host "##vso[task.setvariable variable=skipBuildStep]False"
+      targetType: 'filePath'
+      filePath: 'niveristand-custom-device-build-tools/azure-templates/powershell-scripts/build-step-setup.ps1'
+      failOnStdErr: True
+      arguments: >
+        -projectOverride ${{ parameters.projectOverride }}
+        -projectPath     ${{ parameters.buildStep.projectLocation }}
+        -buildOperation  ${{ parameters.buildStep.buildOperation }}
+        -buildSpec       ${{ parameters.buildStep.buildSpec }}
+        -target          ${{ parameters.buildStep.target }}
 
   - ${{ each exclusion in parameters.buildStep.exclusions }}:
     - ${{ if and( eq(exclusion.version, parameters.lvVersionToBuild.version), eq(exclusion.bitness, parameters.lvVersionToBuild.bitness)) }}:
@@ -67,7 +33,7 @@ steps:
           targetType: 'inline'
           failOnStdErr: true
           script: |
-            Write-Host "##vso[task.setvariable variable=skipBuildStep]True"
+            Write-Host "##vso[task.setvariable variable=CD.SkipThisStep]True"
 
   - ${{ each dependency in parameters.dependencies }}:
     - ${{ if and( ne( dependency.file, '' ), eq( parameters.buildStep.buildOperation, 'ExecuteBuildSpec' ))}}:
@@ -75,94 +41,14 @@ steps:
       - task: PowerShell@2
         displayName: Copy dependency ${{ dependency.file }} to ${{ dependency.destination }}
         inputs:
-          targetType: 'inline'
+          targetType: 'filePath'
+          filePath: 'niveristand-custom-device-build-tools/azure-templates/powershell-scripts/dependency-setup.ps1'
           failOnStdErr: true
-          script: |
-            If ('$(skipBuildStep)' -eq 'True')
-            {
-                Write-Output "dependency copying was skipped because a matching exclusion was found for this build step."
-            }
-            Else
-            {
-              Write-Output "Configuring target directory environment..."
-              If ('${{ parameters.buildStep.target }}' -eq 'My Computer')
-              {
-                $target = "Windows"
-              }
-              Elseif ('${{ parameters.buildStep.target }}' -eq 'Linux x64')
-              {
-                $target = "Linux_x64"
-              }
-              Write-Output "Setting dependency environment to $target"
-              `
-              $branchName = 'main'
-              If ('$(CD.SourceBranch)' -ne $branchName )
-              {
-                Write-Output "Checking for builds of $(CD.SourceBranch) branch..."
-                If (Test-Path -Path "${{ dependency.source }}\NI\export\$(CD.SourceBranch)\*\$(CD.LabVIEW.Version)\$(CD.Architecture)")
-                {
-                  Write-Output "branch was found, using $(CD.SourceBranch) instead of $branchName..."
-                  $branchName = '$(CD.SourceBranch)'
-                }
-                Else
-                {
-                  Write-Output "branch not found, using a build of $branchName..."
-                }
-              }
-              Else
-              {
-                Write-Output "Using $branchName branch..."
-              }
-              `
-              Write-Output "Finding latest successful build of dependency ${{ dependency.file }}..."
-              $allDependencyBuilds = Get-ChildItem `
-                -Path "${{ dependency.source }}\NI\export\$branchName\*" `
-                | Sort {$_.Name} -Descending
-              Foreach ($build in $allDependencyBuilds)
-              {
-                Write-Output "Checking $build..."
-                If (Test-Path -Path "$build\$(CD.LabVIEW.Version)\$(CD.Architecture)\")
-                {
-                  Write-Output "Checking for .finished file..."
-                  If (Test-Path -Path "$build\.finished")
-                  {
-                    Write-Output "latest successful build: $build"
-                    $dependencyFilePath = "$build\$(CD.LabVIEW.Version)\$(CD.Architecture)\${{ dependency.file }}"
-                    Break
-                  }
-                  Else
-                  {
-                    Write-Output ".finished file not found at $build"
-                  }
-                }
-              }
-              If (-not $dependencyFilePath)
-              {
-                Write-Error "no successful build of dependency ${{ dependency.file }} was found at ${{ dependency.source }}."
-                break
-              }
-              `
-              Write-Output "Copying dependency ${{ dependency.file }}..."
-              If (-not(Test-Path -Path "$(CD.Workspace)\$(CD.Repository)\${{ dependency.destination }}"))
-              {
-                New-Item `
-                  -Path "$(CD.Workspace)\$(CD.Repository)\${{ dependency.destination }}" `
-                  -ItemType 'Directory'
-              }
-              If (Test-Path $dependencyFilePath)
-              {
-                Copy-Item `
-                  -Path $dependencyFilePath `
-                  -Destination "$(CD.Workspace)\$(CD.Repository)\${{ dependency.destination }}\" `
-                  -Recurse `
-                  -Force
-              }
-              Else
-              {
-                Write-Output "Dependency does not exist at $dependencyFilePath..."
-                Write-Output "SKIPPING DEPENDENCY, END STEP..."
-              }
-            }
+          arguments: >
+            -source      ${{ dependency.source }}
+            -file        ${{ dependency.file }}
+            -destination ${{ dependency.destination }}
+
     - ${{ if and( ne( dependency.file, '' ), ne( parameters.buildStep.buildOperation, 'ExecuteBuildSpec' ))}}:
       - task: PowerShell@2
         displayName: dependency not used because buildOperation not supported for this buildStep
@@ -175,18 +61,18 @@ steps:
     displayName: Build ${{ parameters.buildStep.buildSpec }} on ${{ parameters.buildStep.target }} in ${{ parameters.buildStep.projectLocation }}
     inputs:
       script: |
-        ECHO on
-        IF "${{ parameters.buildStep.projectOverride}}"=="Absolute" (
-          SET project_path="${{ parameters.buildStep.projectLocation }}"
+        ECHO ON
+        IF $(CD.AbsolutePath) (
+          SET project_path="$(CD.ProjectPath)"
         ) ELSE (
-          SET project_path="$(CD.Workspace)\$(CD.Repository)\${{ parameters.buildStep.projectLocation }}"
+          SET project_path="$(CD.Workspace)\$(CD.Repository)\$(CD.ProjectPath)"
         )
-        IF NOT '$(skipBuildStep)'=='True' (
+        IF NOT $(CD.SkipThisStep) (
           $(CD.LabVIEWCLI) ^
-            -OperationName "${{ parameters.buildStep.buildOperation }}" ^
+            -OperationName "$(CD.BuildOperation)" ^
             -ProjectPath %project_path% ^
-            $(targetArgument) ^
-            $(buildSpecArgument) ^
+            $(CD.TargetArg) ^
+            $(CD.BuildSpecArg) ^
             -LogFilePath "$(CD.Workspace)\$(CD.Repository)\lvBuildSpecs.log"
         )
 
@@ -194,4 +80,4 @@ steps:
     displayName: Close LabVIEW
     condition: always() # close LabVIEW even if previous steps failed
     inputs:
-      script: if not '$(skipBuildStep)'=='True' taskkill /im labview.exe /f
+      script: IF NOT $(CD.SkipThisStep) (taskkill /im labview.exe /f)

--- a/azure-templates/steps-build.yml
+++ b/azure-templates/steps-build.yml
@@ -62,12 +62,12 @@ steps:
     inputs:
       script: |
         ECHO ON
-        IF "$(CD.AbsolutePath)" (
+        IF '$(CD.AbsolutePath)' (
           SET project_path="$(CD.ProjectPath)"
         ) ELSE (
           SET project_path="$(CD.Workspace)\$(CD.Repository)\$(CD.ProjectPath)"
         )
-        IF NOT "$(CD.SkipThisStep)" (
+        IF NOT '$(CD.SkipThisStep)' (
           $(CD.LabVIEWCLI) ^
             -OperationName "$(CD.BuildOperation)" ^
             -ProjectPath %project_path% ^
@@ -80,4 +80,4 @@ steps:
     displayName: Close LabVIEW
     condition: always() # close LabVIEW even if previous steps failed
     inputs:
-      script: IF NOT "$(CD.SkipThisStep)" (taskkill /im labview.exe /f)
+      script: IF NOT '$(CD.SkipThisStep)' (taskkill /im labview.exe /f)

--- a/azure-templates/steps-build.yml
+++ b/azure-templates/steps-build.yml
@@ -44,9 +44,9 @@ steps:
           targetType: 'filePath'
           filePath: 'niveristand-custom-device-build-tools/azure-templates/powershell-scripts/dependency-setup.ps1'
           failOnStdErr: true
-          arguments: >
+          arguments: > # -file has single quotes to pass in a variable
             -source      "${{ dependency.source }}"
-            -file        "${{ dependency.file }}"
+            -file        '${{ dependency.file }}'
             -destination "${{ dependency.destination }}"
 
     - ${{ if and( ne( dependency.file, '' ), ne( parameters.buildStep.buildOperation, 'ExecuteBuildSpec' ))}}:

--- a/azure-templates/steps-build.yml
+++ b/azure-templates/steps-build.yml
@@ -62,12 +62,12 @@ steps:
     inputs:
       script: |
         ECHO ON
-        IF $(CD.AbsolutePath) (
+        IF "$(CD.AbsolutePath)" (
           SET project_path="$(CD.ProjectPath)"
         ) ELSE (
           SET project_path="$(CD.Workspace)\$(CD.Repository)\$(CD.ProjectPath)"
         )
-        IF NOT $(CD.SkipThisStep) (
+        IF NOT "$(CD.SkipThisStep)" (
           $(CD.LabVIEWCLI) ^
             -OperationName "$(CD.BuildOperation)" ^
             -ProjectPath %project_path% ^
@@ -80,4 +80,4 @@ steps:
     displayName: Close LabVIEW
     condition: always() # close LabVIEW even if previous steps failed
     inputs:
-      script: IF NOT $(CD.SkipThisStep) (taskkill /im labview.exe /f)
+      script: IF NOT "$(CD.SkipThisStep)" (taskkill /im labview.exe /f)

--- a/azure-templates/steps-build.yml
+++ b/azure-templates/steps-build.yml
@@ -44,7 +44,7 @@ steps:
           targetType: 'filePath'
           filePath: 'niveristand-custom-device-build-tools/azure-templates/powershell-scripts/dependency-setup.ps1'
           failOnStdErr: true
-          arguments: > # -file has single quotes to pass in a variable
+          arguments: > # -file argument has single quotes because it needs to be able to pass in a variable
             -source      "${{ dependency.source }}"
             -file        '${{ dependency.file }}'
             -destination "${{ dependency.destination }}"

--- a/azure-templates/steps-build.yml
+++ b/azure-templates/steps-build.yml
@@ -19,7 +19,7 @@ steps:
       filePath: 'niveristand-custom-device-build-tools/azure-templates/powershell-scripts/build-step-setup.ps1'
       failOnStdErr: True
       arguments: >
-        -projectOverride ${{ parameters.buildStep.projectOverride }}
+        -projectOverride "${{ parameters.buildStep.projectOverride }}"
         -projectPath     ${{ parameters.buildStep.projectLocation }}
         -buildOperation  ${{ parameters.buildStep.buildOperation }}
         -buildSpec       ${{ parameters.buildStep.buildSpec }}

--- a/azure-templates/steps-build.yml
+++ b/azure-templates/steps-build.yml
@@ -19,7 +19,7 @@ steps:
       filePath: 'niveristand-custom-device-build-tools/azure-templates/powershell-scripts/build-step-setup.ps1'
       failOnStdErr: True
       arguments: >
-        -projectOverride ${{ parameters.projectOverride }}
+        -projectOverride ${{ parameters.buildStep.projectOverride }}
         -projectPath     ${{ parameters.buildStep.projectLocation }}
         -buildOperation  ${{ parameters.buildStep.buildOperation }}
         -buildSpec       ${{ parameters.buildStep.buildSpec }}

--- a/azure-templates/steps-build.yml
+++ b/azure-templates/steps-build.yml
@@ -63,9 +63,9 @@ steps:
       script: |
         ECHO ON
         IF '$(CD.AbsolutePath)'=='True' (
-          SET project_path="$(CD.Workspace)\$(CD.Repository)\$(CD.ProjectPath)"
-        ) ELSE (
           SET project_path="$(CD.ProjectPath)"
+        ) ELSE (
+          SET project_path="$(CD.Workspace)\$(CD.Repository)\$(CD.ProjectPath)"
         )
         IF '$(CD.SkipThisStep)'=='False' (
           $(CD.LabVIEWCLI) ^

--- a/azure-templates/steps-post-build.yml
+++ b/azure-templates/steps-post-build.yml
@@ -4,7 +4,7 @@
 parameters:
   - name: packages
     type: object
-# Note: the following variables are defined in pre-job-steps.yml:
+# Note: the following variables are defined in steps-prepare.yml:
   # CD.Nipkg.Path, CD.Repository, CD.LabVIEW.Version, CD.Release.Version,
   # CD.Release.Quarterly, CD.LabVIEW.ShortVersion, CD.BuildOutputPath,
   # CD.ArchivePath, CD.Architecture


### PR DESCRIPTION
- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-custom-device-build-tools/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Moves the powershell scripts for dependencies and build preparation to powershell scripts.  Command line does not have the same capabilities as powershell, so calling a batch script for CmdLine tasks is not feasible, but since they are relatively short with 1-2 calls inside, that shouldn't be too bad.

### Why should this Pull Request be merged?

Continuing to improve readability and reusability of pipeline code.

### What testing has been done?

This build should pass.