### PR TITLE
Optional error silence for SEECD

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -32,6 +32,8 @@ stages:
         - version: '2023'
           bitness: '64bit'
 
+      silenceDependencyFailures: true
+
 # Test Dependencies - multiple dependencies that are expected in the build steps below this
       dependencies:
         - source: '\\nirvana\Measurements\VeriStandAddons\prototype\dependency-test-1'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -32,8 +32,6 @@ stages:
         - version: '2023'
           bitness: '64bit'
 
-      silenceDependencyFailures: true
-
 # Test Dependencies - multiple dependencies that are expected in the build steps below this
       dependencies:
         - source: '\\nirvana\Measurements\VeriStandAddons\prototype\dependency-test-1'

--- a/azure-templates/powershell-scripts/dependency-setup.ps1
+++ b/azure-templates/powershell-scripts/dependency-setup.ps1
@@ -65,7 +65,7 @@ Else
   }
   If (-not $dependencyFilePath)
   {
-    If ($silence -eq "true")
+    If ($silence -ne "true")
     {
       Write-Error "no successful build of dependency $file was found at $source."
     }
@@ -89,7 +89,7 @@ Else
   }
   Else
   {
-    If ($silence -eq "true")
+    If ($silence -ne "true")
     {
       Write-Error "Dependency does not exist at $dependencyFilePath."
     }

--- a/azure-templates/powershell-scripts/dependency-setup.ps1
+++ b/azure-templates/powershell-scripts/dependency-setup.ps1
@@ -63,15 +63,7 @@ Else
       }
     }
   }
-  If (-not $dependencyFilePath)
-  {
-    If ($silence -ne "true")
-    {
-      Write-Error "no successful build of dependency $file was found at $source."
-    }
-    break
-  }
-  `
+
   Write-Output "Copying dependency $file..."
   If (-not(Test-Path -Path "$env:CD_WORKSPACE\$env:CD_REPOSITORY\$destination"))
   {
@@ -89,7 +81,11 @@ Else
   }
   Else
   {
-    If ($silence -ne "true")
+    If ($silence -eq "true")
+    {
+      Write-Output "Dependency does not exist at $dependencyFilePath. Dependency error silenced, moving on..."
+    }
+    Else 
     {
       Write-Error "Dependency does not exist at $dependencyFilePath."
     }

--- a/azure-templates/powershell-scripts/dependency-setup.ps1
+++ b/azure-templates/powershell-scripts/dependency-setup.ps1
@@ -1,7 +1,8 @@
 param(
     [string]$source,
     [string]$file,
-    [string]$destination
+    [string]$destination,
+    [string]$silence
 )
 
 If ("$env:CD_SKIPTHISSTEP" -eq "True")
@@ -64,7 +65,10 @@ Else
   }
   If (-not $dependencyFilePath)
   {
-    Write-Error "no successful build of dependency $file was found at $source."
+    If ($silence -eq "true")
+    {
+      Write-Error "no successful build of dependency $file was found at $source."
+    }
     break
   }
   `
@@ -85,6 +89,9 @@ Else
   }
   Else
   {
-    Write-Error "Dependency does not exist at $dependencyFilePath."
+    If ($silence -eq "true")
+    {
+      Write-Error "Dependency does not exist at $dependencyFilePath."
+    }
   }
 }

--- a/azure-templates/stages.yml
+++ b/azure-templates/stages.yml
@@ -120,15 +120,15 @@ stages:
                 buildOutputLocation:       ${{ parameters.buildOutputLocation }}
                 codegenVis:                ${{ parameters.codegenVis }}
                 submodules:                ${{ parameters.submodules }}
-                silenceDependencyFailures: ${{ parameters.silenceDependencyFailures }}
 
             - ${{ if ne( parameters.buildSteps, '' )}}:
               - ${{ each buildStep in parameters.buildSteps }}:
                   - template: steps-build.yml # config file and build specs
                     parameters:
-                      buildStep:          ${{ buildStep }}
-                      dependencies:       ${{ parameters.dependencies }}
-                      lvVersionToBuild:   ${{ lvVersionToBuild }}
+                      buildStep:                 ${{ buildStep }}
+                      dependencies:              ${{ parameters.dependencies }}
+                      lvVersionToBuild:          ${{ lvVersionToBuild }}
+                      silenceDependencyFailures: ${{ parameters.silenceDependencyFailures }}
 
             - template: steps-post-build.yml # nipkg and archive
               parameters:

--- a/azure-templates/stages.yml
+++ b/azure-templates/stages.yml
@@ -7,6 +7,10 @@ parameters:
     type: boolean
     default: false
 
+  - name: silenceDependencyFailures
+    type: boolean
+    default: false
+
   # lvVersionsToBuild: list of {version, bitness}
   - name: lvVersionsToBuild
     type: object
@@ -110,12 +114,13 @@ stages:
           steps:
             - template: steps-prepare.yml # Configure variables, check out repos, Clear cache
               parameters:
-                lvVersionToBuild:        ${{ lvVersionToBuild }}
-                releaseVersion:          ${{ parameters.releaseVersion }}
-                archiveLocation:         ${{ parameters.archiveLocation }}
-                buildOutputLocation:     ${{ parameters.buildOutputLocation }}
-                codegenVis:              ${{ parameters.codegenVis }}
-                submodules:              ${{ parameters.submodules }}
+                lvVersionToBuild:          ${{ lvVersionToBuild }}
+                releaseVersion:            ${{ parameters.releaseVersion }}
+                archiveLocation:           ${{ parameters.archiveLocation }}
+                buildOutputLocation:       ${{ parameters.buildOutputLocation }}
+                codegenVis:                ${{ parameters.codegenVis }}
+                submodules:                ${{ parameters.submodules }}
+                silenceDependencyFailures: ${{ parameters.silenceDependencyFailures }}
 
             - ${{ if ne( parameters.buildSteps, '' )}}:
               - ${{ each buildStep in parameters.buildSteps }}:

--- a/azure-templates/steps-build.yml
+++ b/azure-templates/steps-build.yml
@@ -6,6 +6,8 @@ parameters:
     type: object
   - name: lvVersionToBuild
     type: object
+  - name: silenceDependencyFailures
+    type: boolean
 
 # Note: the following variables are defined in steps-prepare.yml:
   # CD.LabVIEW.Version, CD.Architecture, CD.Repository, CD.LabVIEW.Config,
@@ -48,6 +50,7 @@ steps:
             -source      "${{ dependency.source }}"
             -file        '${{ dependency.file }}'
             -destination "${{ dependency.destination }}"
+            -silence     "${{ parameters.silenceDependencyFailures }}"
 
     - ${{ if and( ne( dependency.file, '' ), ne( parameters.buildStep.buildOperation, 'ExecuteBuildSpec' ))}}:
       - task: PowerShell@2


### PR DESCRIPTION
- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-custom-device-build-tools/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Adds a parameter to silently skip when dependencies fail.

### Why should this Pull Request be merged?

SEECD includes dependencies in some bitnesses but not others, and this is the easiest way to accommodate it's unique needs.

### What testing has been done?

SEECD pipeline can't be run before submission since it requires a top level parameter that doesn't existin build-tools main.

Committed the property temporarily to the pipeline and behaved as expected:
![image](https://user-images.githubusercontent.com/42351034/234072481-22fb5a80-92ff-49f0-87c8-7d1791aa9300.png)
