### PR TITLE
shorten payloads

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -102,16 +102,16 @@ stages:
       packages:
         - controlFileName: 'test-build\control-a'
           payloadMaps:
-            - payloadLocation: 'test-build\Built\Output-1A'
+            - payloadLocation: 'Output-1A'
               installLocation: 'documents\National Instruments\NI VeriStand $(CD.LabVIEW.Version)_$(nipkgx64suffix)\Build Tools Test\Output-1A'
-            - payloadLocation: 'test-build\Built\Output-2A'
+            - payloadLocation: 'Output-2A'
               installLocation: 'documents\National Instruments\NI VeriStand $(CD.LabVIEW.Version)_$(nipkgx64suffix)\Build Tools Test\Output-2A'
 
         - controlFileName: 'test-build\control-b'
           payloadMaps:
-            - payloadLocation: 'test-build\Built\Output-1B'
+            - payloadLocation: 'Output-1B'
               installLocation: 'documents\National Instruments\NI VeriStand $(CD.LabVIEW.Version)_$(nipkgx64suffix)\Build Tools Test\Output-1B'
-            - payloadLocation: 'test-build\Built\Output-2B'
+            - payloadLocation: 'Output-2B'
               installLocation: 'documents\National Instruments\NI VeriStand $(CD.LabVIEW.Version)_$(nipkgx64suffix)\Build Tools Test\Output-2B'
 
 # Test Empty cases

--- a/azure-templates/powershell-scripts/packaging/copy-payload.ps1
+++ b/azure-templates/powershell-scripts/packaging/copy-payload.ps1
@@ -26,10 +26,11 @@ Else
     If (Test-Path "$bitnessSpecificPath")
     {
       Write-Output "copying payload from `"$bitnessSpecificPath`" into nipkg/data install directory..."
-      Copy-Item `
-      -Path "$bitnessSpecificPath\*" `
-      -Destination "$env:CD_NIPKG_PATH\data\$installDir" `
-      -Recurse
+      $existingItems = Get-ChildItem -Recurse "$env:CD_NIPKG_PATH\data\$installDir"
+      Copy-Item -Recurse `
+        -Path "$bitnessSpecificPath\*" `
+        -Destination "$env:CD_NIPKG_PATH\data\$installDir" `
+        -Exclude $existingItems
     }
     Else
     {


### PR DESCRIPTION
- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-custom-device-build-tools/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Now that we are using payloads from nirvana archives, we do not need to include the build output path.

### Why should this Pull Request be merged?

If this is not included, we will not have any payloads in the builds

### What testing has been done?

PR Build output
