### PR TITLE
Add file count and size check in pipeline

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -102,16 +102,16 @@ stages:
       packages:
         - controlFileName: 'test-build\control-a'
           payloadMaps:
-            - payloadLocation: 'test-build\Built\Output-1A'
+            - payloadLocation: 'Output-1A'
               installLocation: 'documents\National Instruments\NI VeriStand $(CD.LabVIEW.Version)_$(nipkgx64suffix)\Build Tools Test\Output-1A'
-            - payloadLocation: 'test-build\Built\Output-2A'
+            - payloadLocation: 'Output-2A'
               installLocation: 'documents\National Instruments\NI VeriStand $(CD.LabVIEW.Version)_$(nipkgx64suffix)\Build Tools Test\Output-2A'
 
         - controlFileName: 'test-build\control-b'
           payloadMaps:
-            - payloadLocation: 'test-build\Built\Output-1B'
+            - payloadLocation: 'Output-1B'
               installLocation: 'documents\National Instruments\NI VeriStand $(CD.LabVIEW.Version)_$(nipkgx64suffix)\Build Tools Test\Output-1B'
-            - payloadLocation: 'test-build\Built\Output-2B'
+            - payloadLocation: 'Output-2B'
               installLocation: 'documents\National Instruments\NI VeriStand $(CD.LabVIEW.Version)_$(nipkgx64suffix)\Build Tools Test\Output-2B'
 
 # Test Empty cases

--- a/azure-templates/powershell-scripts/check-count-size.ps1
+++ b/azure-templates/powershell-scripts/check-count-size.ps1
@@ -1,0 +1,58 @@
+param(
+  [string]$archiveDir
+)
+Write-Output "Finding latest successful build of `"main`" for comparison..."
+$allBuildsOfMain = Get-ChildItem `
+  -Path "$archiveDir\NI\export\main\*" `
+  | Sort-Object {$_.Name} -Descending
+ForEach ($build in $allBuildsOfMain)
+{
+  Write-Output "Checking $build..."
+  If (Test-Path -Path "$build")
+  {
+    Write-Output "Checking for .finished file..."
+    If (Test-Path -Path "$build\.finished")
+    {
+      Write-Output "latest successful build: $build"
+      Break
+    }
+    Else
+    {
+      Write-Output ".finished file not found at $build, checking next build..."
+    }
+  }
+}
+$allPackagesMain = Get-ChildItem -Recurse -Path "$build\*\installer\*.nipkg"
+$allPackagesThisBuild = Get-ChildItem -Recurse -Path "$env:ARCHIVE_PATH\*\installer\*.nipkg"
+Write-Output "Total packages in this build: $($allPackagesThisBuild.Count)"
+Write-Output "Total packages in main: $($allPackagesMain.Count)"
+ForEach ($package in $allPackagesThisBuild)
+{
+  $matchingPackage = $allPackagesMain | Where-Object {$_.Name -match ($package.Name.Split("_")[0])}
+  $index = [array]::IndexOf($allPackagesThisBuild, $package)
+  Write-Output "Unpacking $($package.FullName) and comparing to $($matchingPackage.FullName) from `"main`"..."
+
+  $validateDirectory = "$PWD\Validate-$index"
+  $validateOutputs = "$validateDirectory\Outputs"
+  New-Item -Path "$validateOutputs" -ItemType "Directory" | Out-Null
+  tar -xf "$package" -C "$validateDirectory"
+  tar -xf "$validateDirectory\data.tar.gz" -C "$validateOutputs"
+  $filesInValidatePackage = Get-ChildItem -Recurse -Path "$validateOutputs" -File
+  $validateFileCount = $filesInValidatePackage.Count
+  $validateFileSize = ($filesInValidatePackage | Measure-Object -Property "Length" -Sum).Sum
+
+  $compareDirectory = "$PWD\Compare-$index"
+  $compareOutputs = "$compareDirectory\Outputs"
+  New-Item -Path "$compareOutputs" -ItemType "Directory" | Out-Null
+  tar -xf "$matchingPackage" -C "$compareDirectory"
+  tar -xf "$compareDirectory\data.tar.gz" -C "$compareOutputs"
+  $filesInComparePackage = Get-ChildItem -Recurse -Path "$compareOutputs" -File
+  $compareFileCount = $filesInComparePackage.Count
+  $compareFileSize = ($filesInComparePackage | Measure-Object -Property "Length" -Sum).Sum
+
+  Write-Output "            ________________________________"
+  Write-Output "            | FILE COUNT | FILE SIZE (SUM) |"
+  Write-Output "  main      | $($compareFileCount.ToString().PadLeft(10, " ")) | $($compareFileSize.ToString().PadLeft(15, " ")) |"
+  Write-Output "  thisBuild | $($validateFileCount.ToString().PadLeft(10, " ")) | $($validateFileSize.ToString().PadLeft(15, " ")) |"
+  Write-Output "            ________________________________"
+}

--- a/azure-templates/powershell-scripts/check-count-size.ps1
+++ b/azure-templates/powershell-scripts/check-count-size.ps1
@@ -14,6 +14,7 @@ ForEach ($build in $allBuildsOfMain)
     If (Test-Path -Path "$build\.finished")
     {
       Write-Output "latest successful build: $build"
+      $mainPath = $build
       Break
     }
     Else
@@ -22,10 +23,14 @@ ForEach ($build in $allBuildsOfMain)
     }
   }
 }
-$allPackagesMain = Get-ChildItem -Recurse -Path "$build\*\installer\*.nipkg"
+Write-Output "Getting packages in `"$env:ARCHIVE_PATH`"..."
 $allPackagesThisBuild = Get-ChildItem -Recurse -Path "$env:ARCHIVE_PATH\*\installer\*.nipkg"
 Write-Output "Total packages in this build: $($allPackagesThisBuild.Count)"
+
+Write-Output "Getting packages in `"$mainPath`"..."
+$allPackagesMain = Get-ChildItem -Recurse -Path "$mainPath\*\installer\*.nipkg"
 Write-Output "Total packages in main: $($allPackagesMain.Count)"
+
 ForEach ($package in $allPackagesThisBuild)
 {
   $matchingPackage = $allPackagesMain | Where-Object {$_.Name -match ($package.Name.Split("_")[0])}

--- a/azure-templates/powershell-scripts/check-count-size.ps1
+++ b/azure-templates/powershell-scripts/check-count-size.ps1
@@ -43,8 +43,15 @@ ForEach ($package in $allPackagesThisBuild)
   tar -xf "$package" -C "$validateDirectory"
   tar -xf "$validateDirectory\data.tar.gz" -C "$validateOutputs"
   $filesInValidatePackage = Get-ChildItem -Recurse -Path "$validateOutputs" -File
-  $validateFileCount = $filesInValidatePackage.Count
-  $validateFileSize = ($filesInValidatePackage | Measure-Object -Property "Length" -Sum).Sum
+  If ($filesInValidatePackage)
+  {
+    $validateFileCount = $filesInValidatePackage.Count
+    $validateFileSize = ($filesInValidatePackage | Measure-Object -Property "Length" -Sum).Sum  
+  }
+  Else 
+  {
+    $validateFileCount = $validateFileSize = 0
+  }
 
   $compareDirectory = "$PWD\Compare-$index"
   $compareOutputs = "$compareDirectory\Outputs"
@@ -52,15 +59,19 @@ ForEach ($package in $allPackagesThisBuild)
   tar -xf "$matchingPackage" -C "$compareDirectory"
   tar -xf "$compareDirectory\data.tar.gz" -C "$compareOutputs"
   $filesInComparePackage = Get-ChildItem -Recurse -Path "$compareOutputs" -File
-  $compareFileCount = $filesInComparePackage.Count
-  $compareFileSize = ($filesInComparePackage | Measure-Object -Property "Length" -Sum).Sum
-
-  If (-and($compareFileCount, $validateFileCount, $compareFileSize, $validateFileSize))
+  If ($filesInComparePackage)
   {
+    $compareFileCount = $filesInComparePackage.Count
+    $compareFileSize = ($filesInComparePackage | Measure-Object -Property "Length" -Sum).Sum  
+  }
+  Else 
+  {
+    $compareFileCount = $compareFileSize = 0
+  }
+
     Write-Output "            ________________________________"
     Write-Output "            | FILE COUNT | FILE SIZE (SUM) |"
     Write-Output "  main      | $($compareFileCount.ToString().PadLeft(10, " ")) | $($compareFileSize.ToString().PadLeft(15, " ")) |"
     Write-Output "  thisBuild | $($validateFileCount.ToString().PadLeft(10, " ")) | $($validateFileSize.ToString().PadLeft(15, " ")) |"
     Write-Output "            ________________________________"
-  }
 }

--- a/azure-templates/powershell-scripts/check-count-size.ps1
+++ b/azure-templates/powershell-scripts/check-count-size.ps1
@@ -34,10 +34,9 @@ Write-Output "Total packages in main: $($allPackagesMain.Count)"
 ForEach ($package in $allPackagesThisBuild)
 {
   $matchingPackage = $allPackagesMain | Where-Object {$_.Name -match ($package.Name.Split("_")[0])}
-  $index = [array]::IndexOf($allPackagesThisBuild, $package)
   Write-Output "Unpacking $($package.FullName) and comparing to $($matchingPackage.FullName) from `"main`"..."
 
-  $validateDirectory = "$PWD\Validate-$index"
+  $validateDirectory = "$PWD\Validate"
   $validateOutputs = "$validateDirectory\Outputs"
   New-Item -Path "$validateOutputs" -ItemType "Directory" | Out-Null
   tar -xf "$package" -C "$validateDirectory"
@@ -53,7 +52,7 @@ ForEach ($package in $allPackagesThisBuild)
     $validateFileCount = $validateFileSize = 0
   }
 
-  $compareDirectory = "$PWD\Compare-$index"
+  $compareDirectory = "$PWD\Compare"
   $compareOutputs = "$compareDirectory\Outputs"
   New-Item -Path "$compareOutputs" -ItemType "Directory" | Out-Null
   tar -xf "$matchingPackage" -C "$compareDirectory"
@@ -69,9 +68,12 @@ ForEach ($package in $allPackagesThisBuild)
     $compareFileCount = $compareFileSize = 0
   }
 
-    Write-Output "            ________________________________"
-    Write-Output "            | FILE COUNT | FILE SIZE (SUM) |"
-    Write-Output "  main      | $($compareFileCount.ToString().PadLeft(10, " ")) | $($compareFileSize.ToString().PadLeft(15, " ")) |"
-    Write-Output "  thisBuild | $($validateFileCount.ToString().PadLeft(10, " ")) | $($validateFileSize.ToString().PadLeft(15, " ")) |"
-    Write-Output "            ________________________________"
+  Write-Output "            ________________________________"
+  Write-Output "            | FILE COUNT | FILE SIZE (SUM) |"
+  Write-Output "  main      | $($compareFileCount.ToString().PadLeft(10, " ")) | $($compareFileSize.ToString().PadLeft(15, " ")) |"
+  Write-Output "  thisBuild | $($validateFileCount.ToString().PadLeft(10, " ")) | $($validateFileSize.ToString().PadLeft(15, " ")) |"
+  Write-Output "            ________________________________"
+  
+  Remove-Item -Recurse -Path "$validateDirectory"
+  Remove-Item -Recurse -Path "$compareDirectory"
 }

--- a/azure-templates/powershell-scripts/check-count-size.ps1
+++ b/azure-templates/powershell-scripts/check-count-size.ps1
@@ -4,7 +4,7 @@ param(
 
 If (-not(Test-Path -Path "$archiveDir\NI\export\main"))
 {
-  Write-Output "Main has not been built yet, skipping this step..."
+  Write-Output "`"main`" has not been built yet, skipping this step..."
 }
 Else
 {
@@ -12,6 +12,7 @@ Else
   $allBuildsOfMain = Get-ChildItem `
     -Path "$archiveDir\NI\export\main\*" `
     | Sort-Object {$_.Name} -Descending
+  $mainPath = "Undefined"
   ForEach ($build in $allBuildsOfMain)
   {
     Write-Output "Checking $build..."
@@ -27,11 +28,10 @@ Else
       Else
       {
         Write-Output ".finished file not found at $build, checking next build..."
-        $mainPath = "Not Found"
       }
     }
   }
-  If ($mainPath -eq "Not Found")
+  If ($mainPath -eq "Undefined")
   {
     Write-Output "No builds were found in main to compare, so skipping the rest of this step..."
   }

--- a/azure-templates/powershell-scripts/check-count-size.ps1
+++ b/azure-templates/powershell-scripts/check-count-size.ps1
@@ -55,9 +55,12 @@ ForEach ($package in $allPackagesThisBuild)
   $compareFileCount = $filesInComparePackage.Count
   $compareFileSize = ($filesInComparePackage | Measure-Object -Property "Length" -Sum).Sum
 
-  Write-Output "            ________________________________"
-  Write-Output "            | FILE COUNT | FILE SIZE (SUM) |"
-  Write-Output "  main      | $($compareFileCount.ToString().PadLeft(10, " ")) | $($compareFileSize.ToString().PadLeft(15, " ")) |"
-  Write-Output "  thisBuild | $($validateFileCount.ToString().PadLeft(10, " ")) | $($validateFileSize.ToString().PadLeft(15, " ")) |"
-  Write-Output "            ________________________________"
+  If (-and($compareFileCount, $validateFileCount, $compareFileSize, $validateFileSize))
+  {
+    Write-Output "            ________________________________"
+    Write-Output "            | FILE COUNT | FILE SIZE (SUM) |"
+    Write-Output "  main      | $($compareFileCount.ToString().PadLeft(10, " ")) | $($compareFileSize.ToString().PadLeft(15, " ")) |"
+    Write-Output "  thisBuild | $($validateFileCount.ToString().PadLeft(10, " ")) | $($validateFileSize.ToString().PadLeft(15, " ")) |"
+    Write-Output "            ________________________________"
+  }
 }

--- a/azure-templates/powershell-scripts/check-count-size.ps1
+++ b/azure-templates/powershell-scripts/check-count-size.ps1
@@ -23,8 +23,8 @@ ForEach ($build in $allBuildsOfMain)
     }
   }
 }
-Write-Output "Getting packages in `"$env:CD_ARCHIVEPATH`"..."
-$allPackagesThisBuild = Get-ChildItem -Recurse -Path "$env:CD_ARCHIVEPATH\*\installer\*.nipkg"
+Write-Output "Getting packages in `"$env:CD_ARCHIVEPATH\$env:BUILD_BUILDNUMBER`"..."
+$allPackagesThisBuild = Get-ChildItem -Recurse -Path "$env:CD_ARCHIVEPATH\$env:BUILD_BUILDNUMBER\*\installer\*.nipkg"
 Write-Output "Total packages in this build: $($allPackagesThisBuild.Count)"
 
 Write-Output "Getting packages in `"$mainPath`"..."

--- a/azure-templates/powershell-scripts/check-count-size.ps1
+++ b/azure-templates/powershell-scripts/check-count-size.ps1
@@ -1,79 +1,95 @@
 param(
   [string]$archiveDir
 )
-Write-Output "Finding latest successful build of `"main`" for comparison..."
-$allBuildsOfMain = Get-ChildItem `
-  -Path "$archiveDir\NI\export\main\*" `
-  | Sort-Object {$_.Name} -Descending
-ForEach ($build in $allBuildsOfMain)
+
+If (-not(Test-Path -Path "$archiveDir\NI\export\main"))
 {
-  Write-Output "Checking $build..."
-  If (Test-Path -Path "$build")
-  {
-    Write-Output "Checking for .finished file..."
-    If (Test-Path -Path "$build\.finished")
-    {
-      Write-Output "latest successful build: $build"
-      $mainPath = $build
-      Break
-    }
-    Else
-    {
-      Write-Output ".finished file not found at $build, checking next build..."
-    }
-  }
+  Write-Output "Main has not been built yet, skipping this step..."
 }
-Write-Output "Getting packages in `"$env:CD_ARCHIVEPATH\$env:BUILD_BUILDNUMBER`"..."
-$allPackagesThisBuild = Get-ChildItem -Recurse -Path "$env:CD_ARCHIVEPATH\$env:BUILD_BUILDNUMBER\*\installer\*.nipkg"
-Write-Output "Total packages in this build: $($allPackagesThisBuild.Count)"
-
-Write-Output "Getting packages in `"$mainPath`"..."
-$allPackagesMain = Get-ChildItem -Recurse -Path "$mainPath\*\installer\*.nipkg"
-Write-Output "Total packages in main: $($allPackagesMain.Count)"
-
-ForEach ($package in $allPackagesThisBuild)
+Else
 {
-  $matchingPackage = $allPackagesMain | Where-Object {$_.Name -match ($package.Name.Split("_")[0])}
-  Write-Output "Unpacking $($package.FullName) and comparing to $($matchingPackage.FullName) from `"main`"..."
+  Write-Output "Finding latest successful build of `"main`" for comparison..."
+  $allBuildsOfMain = Get-ChildItem `
+    -Path "$archiveDir\NI\export\main\*" `
+    | Sort-Object {$_.Name} -Descending
+  ForEach ($build in $allBuildsOfMain)
+  {
+    Write-Output "Checking $build..."
+    If (Test-Path -Path "$build")
+    {
+      Write-Output "Checking for .finished file..."
+      If (Test-Path -Path "$build\.finished")
+      {
+        Write-Output "latest successful build: $build"
+        $mainPath = $build
+        Break
+      }
+      Else
+      {
+        Write-Output ".finished file not found at $build, checking next build..."
+        $mainPath = "Not Found"
+      }
+    }
+  }
+  If ($mainPath -eq "Not Found")
+  {
+    Write-Output "No builds were found in main to compare, so skipping the rest of this step..."
+  }
+  Else
+  {
+    Write-Output "Getting packages in `"$env:CD_ARCHIVEPATH\$env:BUILD_BUILDNUMBER`"..."
+    $allPackagesThisBuild = Get-ChildItem -Recurse -Path "$env:CD_ARCHIVEPATH\$env:BUILD_BUILDNUMBER\*\installer\*.nipkg"
+    Write-Output "Total packages in this build: $($allPackagesThisBuild.Count)"
 
-  $validateDirectory = "$PWD\Validate"
-  $validateOutputs = "$validateDirectory\Outputs"
-  New-Item -Path "$validateOutputs" -ItemType "Directory" | Out-Null
-  tar -xf "$package" -C "$validateDirectory"
-  tar -xf "$validateDirectory\data.tar.gz" -C "$validateOutputs"
-  $filesInValidatePackage = Get-ChildItem -Recurse -Path "$validateOutputs" -File
-  If ($filesInValidatePackage)
-  {
-    $validateFileCount = $filesInValidatePackage.Count
-    $validateFileSize = ($filesInValidatePackage | Measure-Object -Property "Length" -Sum).Sum  
-  }
-  Else 
-  {
-    $validateFileCount = $validateFileSize = 0
-  }
+    Write-Output "Getting packages in `"$mainPath`"..."
+    $allPackagesMain = Get-ChildItem -Recurse -Path "$mainPath\*\installer\*.nipkg"
+    Write-Output "Total packages in main: $($allPackagesMain.Count)"
 
-  $compareDirectory = "$PWD\Compare"
-  $compareOutputs = "$compareDirectory\Outputs"
-  New-Item -Path "$compareOutputs" -ItemType "Directory" | Out-Null
-  tar -xf "$matchingPackage" -C "$compareDirectory"
-  tar -xf "$compareDirectory\data.tar.gz" -C "$compareOutputs"
-  $filesInComparePackage = Get-ChildItem -Recurse -Path "$compareOutputs" -File
-  If ($filesInComparePackage)
-  {
-    $compareFileCount = $filesInComparePackage.Count
-    $compareFileSize = ($filesInComparePackage | Measure-Object -Property "Length" -Sum).Sum  
-  }
-  Else 
-  {
-    $compareFileCount = $compareFileSize = 0
-  }
+    ForEach ($package in $allPackagesThisBuild)
+    {
+      $matchingPackage = $allPackagesMain | Where-Object {$_.Name -match ($package.Name.Split("_")[0])}
+      Write-Output "Unpacking $($package.FullName) and comparing to $($matchingPackage.FullName) from `"main`"..."
 
-  Write-Output "            ________________________________"
-  Write-Output "            | FILE COUNT | FILE SIZE (SUM) |"
-  Write-Output "  main      | $($compareFileCount.ToString().PadLeft(10, " ")) | $($compareFileSize.ToString().PadLeft(15, " ")) |"
-  Write-Output "  thisBuild | $($validateFileCount.ToString().PadLeft(10, " ")) | $($validateFileSize.ToString().PadLeft(15, " ")) |"
-  Write-Output "            ________________________________"
-  
-  Remove-Item -Recurse -Path "$validateDirectory"
-  Remove-Item -Recurse -Path "$compareDirectory"
+      $validateDirectory = "$PWD\Validate"
+      $validateOutputs = "$validateDirectory\Outputs"
+      New-Item -Path "$validateOutputs" -ItemType "Directory" | Out-Null
+      tar -xf "$package" -C "$validateDirectory"
+      tar -xf "$validateDirectory\data.tar.gz" -C "$validateOutputs"
+      $filesInValidatePackage = Get-ChildItem -Recurse -Path "$validateOutputs" -File
+      If ($filesInValidatePackage)
+      {
+        $validateFileCount = $filesInValidatePackage.Count
+        $validateFileSize = ($filesInValidatePackage | Measure-Object -Property "Length" -Sum).Sum  
+      }
+      Else 
+      {
+        $validateFileCount = $validateFileSize = 0
+      }
+
+      $compareDirectory = "$PWD\Compare"
+      $compareOutputs = "$compareDirectory\Outputs"
+      New-Item -Path "$compareOutputs" -ItemType "Directory" | Out-Null
+      tar -xf "$matchingPackage" -C "$compareDirectory"
+      tar -xf "$compareDirectory\data.tar.gz" -C "$compareOutputs"
+      $filesInComparePackage = Get-ChildItem -Recurse -Path "$compareOutputs" -File
+      If ($filesInComparePackage)
+      {
+        $compareFileCount = $filesInComparePackage.Count
+        $compareFileSize = ($filesInComparePackage | Measure-Object -Property "Length" -Sum).Sum  
+      }
+      Else 
+      {
+        $compareFileCount = $compareFileSize = 0
+      }
+
+      Write-Output "            ________________________________"
+      Write-Output "            | FILE COUNT | FILE SIZE (SUM) |"
+      Write-Output "  main      | $($compareFileCount.ToString().PadLeft(10, " ")) | $($compareFileSize.ToString().PadLeft(15, " ")) |"
+      Write-Output "  thisBuild | $($validateFileCount.ToString().PadLeft(10, " ")) | $($validateFileSize.ToString().PadLeft(15, " ")) |"
+      Write-Output "            ________________________________"
+      
+      Remove-Item -Recurse -Path "$validateDirectory"
+      Remove-Item -Recurse -Path "$compareDirectory"
+    }
+  }
 }

--- a/azure-templates/powershell-scripts/check-count-size.ps1
+++ b/azure-templates/powershell-scripts/check-count-size.ps1
@@ -23,8 +23,8 @@ ForEach ($build in $allBuildsOfMain)
     }
   }
 }
-Write-Output "Getting packages in `"$env:ARCHIVE_PATH`"..."
-$allPackagesThisBuild = Get-ChildItem -Recurse -Path "$env:ARCHIVE_PATH\*\installer\*.nipkg"
+Write-Output "Getting packages in `"$env:CD_ARCHIVEPATH`"..."
+$allPackagesThisBuild = Get-ChildItem -Recurse -Path "$env:CD_ARCHIVEPATH\*\installer\*.nipkg"
 Write-Output "Total packages in this build: $($allPackagesThisBuild.Count)"
 
 Write-Output "Getting packages in `"$mainPath`"..."

--- a/azure-templates/powershell-scripts/define-essentials.ps1
+++ b/azure-templates/powershell-scripts/define-essentials.ps1
@@ -24,6 +24,6 @@ If (Test-Path -Path "$archiveDir\NI\export\$sourceBranch\norebuild")
     Exit 1
 }
 
-$archiveFullPath = "$archiveDir\NI\export\$sourceBranch\"
+$archiveFullPath = "$archiveDir\NI\export\$sourceBranch"
 Write-Output "Using `"$archiveFullPath`" as archive path..."
 Write-Host "##vso[task.setvariable variable=CD.ArchivePath]$archiveFullPath"

--- a/azure-templates/powershell-scripts/packaging/copy-payload.ps1
+++ b/azure-templates/powershell-scripts/packaging/copy-payload.ps1
@@ -26,10 +26,11 @@ Else
     If (Test-Path "$bitnessSpecificPath")
     {
       Write-Output "copying payload from `"$bitnessSpecificPath`" into nipkg/data install directory..."
-      Copy-Item `
-      -Path "$bitnessSpecificPath\*" `
-      -Destination "$env:CD_NIPKG_PATH\data\$installDir" `
-      -Recurse
+      $existingItems = Get-ChildItem -Recurse "$env:CD_NIPKG_PATH\data\$installDir"
+      Copy-Item -Recurse `
+        -Path "$bitnessSpecificPath\*" `
+        -Destination "$env:CD_NIPKG_PATH\data\$installDir" `
+        -Exclude $existingItems
     }
     Else
     {

--- a/azure-templates/stages.yml
+++ b/azure-templates/stages.yml
@@ -182,7 +182,7 @@ stages:
             filePath: 'niveristand-custom-device-build-tools/azure-templates/powershell-scripts/check-count-size.ps1'
             failOnStdErr: True
             arguments: >
-              -archiveDir "${{ paramters.archiveLocation }}"
+              -archiveDir "${{ parameters.archiveLocation }}"
 
         - task: PowerShell@2
           displayName: Add .finished to directory

--- a/azure-templates/stages.yml
+++ b/azure-templates/stages.yml
@@ -176,6 +176,15 @@ stages:
             clearCache: False
 
         - task: PowerShell@2
+          displayName: Compare package contents to last successful build in main
+          inputs:
+            targetType: 'filePath'
+            filePath: 'niveristand-custom-device-build-tools/azure-templates/powershell-scripts/check-count-size.ps1'
+            failOnStdErr: True
+            arguments: >
+              -archiveDir "${{ paramters.archiveLocation }}"
+
+        - task: PowerShell@2
           displayName: Add .finished to directory
           inputs:
             targetType: 'filePath'


### PR DESCRIPTION
- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-custom-device-build-tools/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

* Adds a step to the Final Verification pipeline that compares the sizes and file counts in all of the package files output by the build to the last successful build of main

### Why should this Pull Request be merged?

* This is the most common way that we manually validate a pipeline is building correctly.

### What testing has been done?

* Tested with build-tools (see PR output), and also ran it with SLSC-12201 CD:
![image](https://user-images.githubusercontent.com/42351034/235715232-c571fee3-9779-42b6-913d-e31a8a58d890.png)
