### PR TITLE
add an underscore to ensure exact package name matches

### DIFF
--- a/azure-templates/powershell-scripts/check-count-size.ps1
+++ b/azure-templates/powershell-scripts/check-count-size.ps1
@@ -47,7 +47,7 @@ Else
 
     ForEach ($package in $allPackagesThisBuild)
     {
-      $matchingPackage = $allPackagesMain | Where-Object {$_.Name -match ($package.Name.Split("_")[0])}
+      $matchingPackage = $allPackagesMain | Where-Object {$_.Name -match "$($package.Name.Split("_")[0])_"}
       Write-Output "Unpacking $($package.FullName) and comparing to $($matchingPackage.FullName) from `"main`"..."
 
       $validateDirectory = "$PWD\Validate"


### PR DESCRIPTION
- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-custom-device-build-tools/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Adds an _ to the match to ensure that packages will not include partial matches, to address FPGA Addon for example.

### Why should this Pull Request be merged?

Some builds require this since they have packages that fully include the name of other packages, such as FPGA Addon.

### What testing has been done?

Works with FPGA Addon:
![image](https://user-images.githubusercontent.com/42351034/235769810-659dfc92-1b29-4f8a-8c06-7fdf7d7f515c.png)

Note:  the last successful build of FPGA Addon had empty packages:
![image](https://user-images.githubusercontent.com/42351034/235769783-4bd0f1d0-7ee8-4967-8b5d-ff1845d9d10c.png)
