### PR TITLE
skip comparison of packages if there is nothing matching in main

### DIFF
--- a/azure-templates/powershell-scripts/check-count-size.ps1
+++ b/azure-templates/powershell-scripts/check-count-size.ps1
@@ -48,48 +48,55 @@ Else
     ForEach ($package in $allPackagesThisBuild)
     {
       $matchingPackage = $allPackagesMain | Where-Object {$_.Name -match "$($package.Name.Split("_")[0])_"}
-      Write-Output "Unpacking $($package.FullName) and comparing to $($matchingPackage.FullName) from `"main`"..."
+      If (Test-Path -Path "$matchingPackage")
+      {
+        Write-Output "Unpacking $($package.FullName) and comparing to $($matchingPackage.FullName) from `"main`"..."
 
-      $validateDirectory = "$PWD\Validate"
-      $validateOutputs = "$validateDirectory\Outputs"
-      New-Item -Path "$validateOutputs" -ItemType "Directory" | Out-Null
-      tar -xf "$package" -C "$validateDirectory"
-      tar -xf "$validateDirectory\data.tar.gz" -C "$validateOutputs"
-      $filesInValidatePackage = Get-ChildItem -Recurse -Path "$validateOutputs" -File
-      If ($filesInValidatePackage)
-      {
-        $validateFileCount = $filesInValidatePackage.Count
-        $validateFileSize = ($filesInValidatePackage | Measure-Object -Property "Length" -Sum).Sum  
-      }
-      Else 
-      {
-        $validateFileCount = $validateFileSize = 0
-      }
+        $validateDirectory = "$PWD\Validate"
+        $validateOutputs = "$validateDirectory\Outputs"
+        New-Item -Path "$validateOutputs" -ItemType "Directory" | Out-Null
+        tar -xf "$package" -C "$validateDirectory"
+        tar -xf "$validateDirectory\data.tar.gz" -C "$validateOutputs"
+        $filesInValidatePackage = Get-ChildItem -Recurse -Path "$validateOutputs" -File
+        If ($filesInValidatePackage)
+        {
+          $validateFileCount = $filesInValidatePackage.Count
+          $validateFileSize = ($filesInValidatePackage | Measure-Object -Property "Length" -Sum).Sum  
+        }
+        Else 
+        {
+          $validateFileCount = $validateFileSize = 0
+        }
 
-      $compareDirectory = "$PWD\Compare"
-      $compareOutputs = "$compareDirectory\Outputs"
-      New-Item -Path "$compareOutputs" -ItemType "Directory" | Out-Null
-      tar -xf "$matchingPackage" -C "$compareDirectory"
-      tar -xf "$compareDirectory\data.tar.gz" -C "$compareOutputs"
-      $filesInComparePackage = Get-ChildItem -Recurse -Path "$compareOutputs" -File
-      If ($filesInComparePackage)
-      {
-        $compareFileCount = $filesInComparePackage.Count
-        $compareFileSize = ($filesInComparePackage | Measure-Object -Property "Length" -Sum).Sum  
-      }
-      Else 
-      {
-        $compareFileCount = $compareFileSize = 0
-      }
+        $compareDirectory = "$PWD\Compare"
+        $compareOutputs = "$compareDirectory\Outputs"
+        New-Item -Path "$compareOutputs" -ItemType "Directory" | Out-Null
+        tar -xf "$matchingPackage" -C "$compareDirectory"
+        tar -xf "$compareDirectory\data.tar.gz" -C "$compareOutputs"
+        $filesInComparePackage = Get-ChildItem -Recurse -Path "$compareOutputs" -File
+        If ($filesInComparePackage)
+        {
+          $compareFileCount = $filesInComparePackage.Count
+          $compareFileSize = ($filesInComparePackage | Measure-Object -Property "Length" -Sum).Sum  
+        }
+        Else 
+        {
+          $compareFileCount = $compareFileSize = 0
+        }
 
-      Write-Output "            ________________________________"
-      Write-Output "            | FILE COUNT | FILE SIZE (SUM) |"
-      Write-Output "  main      | $($compareFileCount.ToString().PadLeft(10, " ")) | $($compareFileSize.ToString().PadLeft(15, " ")) |"
-      Write-Output "  thisBuild | $($validateFileCount.ToString().PadLeft(10, " ")) | $($validateFileSize.ToString().PadLeft(15, " ")) |"
-      Write-Output "            ________________________________"
-      
-      Remove-Item -Recurse -Path "$validateDirectory"
-      Remove-Item -Recurse -Path "$compareDirectory"
+        Write-Output "            ________________________________"
+        Write-Output "            | FILE COUNT | FILE SIZE (SUM) |"
+        Write-Output "  main      | $($compareFileCount.ToString().PadLeft(10, " ")) | $($compareFileSize.ToString().PadLeft(15, " ")) |"
+        Write-Output "  thisBuild | $($validateFileCount.ToString().PadLeft(10, " ")) | $($validateFileSize.ToString().PadLeft(15, " ")) |"
+        Write-Output "            ________________________________"
+        
+        Remove-Item -Recurse -Path "$validateDirectory"
+        Remove-Item -Recurse -Path "$compareDirectory"
+      }
+      Else
+      {
+        Write-Output "Skipping `"$($package.FullName)`" because could not find a matching package at `"$($matchingPackage.FullName)`""
+      }
     }
   }
 }

--- a/azure-templates/powershell-scripts/check-count-size.ps1
+++ b/azure-templates/powershell-scripts/check-count-size.ps1
@@ -48,7 +48,7 @@ Else
     ForEach ($package in $allPackagesThisBuild)
     {
       $matchingPackage = $allPackagesMain | Where-Object {$_.Name -match "$($package.Name.Split("_")[0])_"}
-      If (Test-Path -Path "$matchingPackage")
+      If ("$matchingPackage" -ne "")
       {
         Write-Output "Unpacking $($package.FullName) and comparing to $($matchingPackage.FullName) from `"main`"..."
 

--- a/azure-templates/powershell-scripts/check-count-size.ps1
+++ b/azure-templates/powershell-scripts/check-count-size.ps1
@@ -95,7 +95,7 @@ Else
       }
       Else
       {
-        Write-Output "Skipping `"$($package.FullName)`" because could not find a matching package at `"$($matchingPackage.FullName)`""
+        Write-Output "Skipping `"$($package.FullName)`" because could not find a matching package."
       }
     }
   }


### PR DESCRIPTION
- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-custom-device-build-tools/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Checks for whether a matching package actually exists in main before doing the comparison for file count and size.

### Why should this Pull Request be merged?

If a package is added (e.g. support for a new verison of LabVIEW) this comparison should be skipped silently instead of erroring.

### What testing has been done?

Temporarily removed the 2023 export for the latest in main for this PR build:
![image](https://github.com/ni/niveristand-custom-device-build-tools/assets/42351034/0fb08f64-c3f8-4680-bc66-95ba20b23b69)

When running in this state, build still passes with packages skipped:
![image](https://github.com/ni/niveristand-custom-device-build-tools/assets/42351034/ac8cad08-4358-4f69-93e3-e1aa38283b36)
