### PR TITLE
Add empty package fail case, and fix nipkg branch issue

### DIFF
--- a/azure-templates/powershell-scripts/check-count-size.ps1
+++ b/azure-templates/powershell-scripts/check-count-size.ps1
@@ -1,5 +1,6 @@
 param(
-  [string]$archiveDir
+  [string]$archiveDir,
+  [boolean]$virtualPackages
 )
 
 If (-not(Test-Path -Path "$archiveDir\NI\export\main"))
@@ -84,14 +85,19 @@ Else
           $compareFileCount = $compareFileSize = 0
         }
 
-        Write-Output "            ________________________________"
-        Write-Output "            | FILE COUNT | FILE SIZE (SUM) |"
-        Write-Output "  main      | $($compareFileCount.ToString().PadLeft(10, " ")) | $($compareFileSize.ToString().PadLeft(15, " ")) |"
-        Write-Output "  thisBuild | $($validateFileCount.ToString().PadLeft(10, " ")) | $($validateFileSize.ToString().PadLeft(15, " ")) |"
+        Write-Output "             ________________________________"
+        Write-Output "             | FILE COUNT | FILE SIZE (SUM) |"
+        Write-Output "  main       | $($compareFileCount.ToString().PadLeft(10, " ")) | $($compareFileSize.ToString().PadLeft(15, " ")) |"
+        Write-Output "  this build | $($validateFileCount.ToString().PadLeft(10, " ")) | $($validateFileSize.ToString().PadLeft(15, " ")) |"
         Write-Output "            ________________________________"
         
         Remove-Item -Recurse -Path "$validateDirectory"
         Remove-Item -Recurse -Path "$compareDirectory"
+        If (($validateFileCount -eq 0) -and (-not($virtualPackages)))
+        {
+          Write-Output "this build's package file `"$($package.Name)`" has no files in it, so validation has failed.  Exiting..."
+          Exit 1
+        }
       }
       Else
       {

--- a/azure-templates/powershell-scripts/packaging/manifest-release-tags.ps1
+++ b/azure-templates/powershell-scripts/packaging/manifest-release-tags.ps1
@@ -33,7 +33,7 @@ Else
     {
       If (-not("$packageFile" -match "$cleanedSourceBranch.nipkg"))
       {
-        Rename-Item -Path "$packageFile" -NewName ("$packageFile" -replace ".nipkg", "_$cleanedSourceBranch.nipkg")
+        Rename-Item -Path "$packageFile" -NewName ("$packageFile" -replace "\.nipkg", "_$cleanedSourceBranch.nipkg")
       }
     }
   }

--- a/azure-templates/stages.yml
+++ b/azure-templates/stages.yml
@@ -7,6 +7,10 @@ parameters:
     type: boolean
     default: false
 
+  - name: enableVirtualPackages
+    type: boolean
+    default: false
+
   - name: silenceDependencyFailures
     type: boolean
     default: false
@@ -181,8 +185,9 @@ stages:
             targetType: 'filePath'
             filePath: 'niveristand-custom-device-build-tools/azure-templates/powershell-scripts/check-count-size.ps1'
             failOnStdErr: True
-            arguments: >
+            arguments: > # $$ is used in an argument to pass in a boolean, which requires a $ at the beginning
               -archiveDir "${{ parameters.archiveLocation }}"
+              -virtualPackages $${{ parameters.enableVirtualPackages }}
 
         - task: PowerShell@2
           displayName: Add .finished to directory


### PR DESCRIPTION
- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-custom-device-build-tools/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

* Fails verification if package files have no files in them, now that we are checking anyway.
* If someone wants to build an empty package (just a control file for install recommendations) they can use the optional parameter **enableVirtualPackages: true** in the top level pipeline.
* Also updates a regex to use the literal period instead of a wildcard to avoid unexpected failures with certain branch names

### Why should this Pull Request be merged?

Packages should not usually be empty, so we might as well catch the error case.
Also fixes a bug that would impact any dev branch with "nipkg" in the name

### What testing has been done?

Tested with dev tools, which was making empty packages at the time of the test:
![image](https://user-images.githubusercontent.com/42351034/235983644-ba5cbe41-6d9b-49c4-8b09-1769739d6b24.png)

Then tested with a special branch of build-tools with enableVirtualPackage:
![image](https://github.com/ni/niveristand-custom-device-build-tools/assets/42351034/9e71d676-557e-48e2-b025-fdf56619db75)
this works.

This PR should not fail, to verify the existing case.