### PR TITLE
Fix release branch builds with no packages

### DIFF
--- a/azure-templates/powershell-scripts/packaging/manifest-release-tags.ps1
+++ b/azure-templates/powershell-scripts/packaging/manifest-release-tags.ps1
@@ -2,6 +2,10 @@ If ("$env:CD_PACKAGE_FINISHED" -match "$env:CD_LABVIEW_VERSION")
 {
   Write-Output "Package already built for this version of LabVIEW... skipping this step."
 }
+ElseIf ($null -eq $env:CD_INSTALLERPATH)
+{
+  Write-Output "No packages were built as part of this build... skipping this step."
+}
 Else
 {
   If ( ("$env:CD_SOURCEBRANCH" -match "release") -and (Test-Path $env:CD_INSTALLERPATH) )

--- a/azure-templates/steps-packaging.yml
+++ b/azure-templates/steps-packaging.yml
@@ -44,6 +44,7 @@ steps:
 
   - task: PowerShell@2
     displayName: ${{ parameters.lvVersion }} Manifest, nipkg labels, and mark package built
+    condition: ne('${{ parameters.packages.controlFileName }}', '')
     inputs:
       targetType: 'filePath'
       filePath: 'niveristand-custom-device-build-tools/azure-templates/powershell-scripts/packaging/manifest-release-tags.ps1'

--- a/azure-templates/steps-packaging.yml
+++ b/azure-templates/steps-packaging.yml
@@ -44,7 +44,6 @@ steps:
 
   - task: PowerShell@2
     displayName: ${{ parameters.lvVersion }} Manifest, nipkg labels, and mark package built
-    condition: ne('${{ parameters.packages.controlFileName }}', '')
     inputs:
       targetType: 'filePath'
       filePath: 'niveristand-custom-device-build-tools/azure-templates/powershell-scripts/packaging/manifest-release-tags.ps1'


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-custom-device-build-tools/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Check whether `CD_INSTALLERPATH` is null before testing if the path is populated for release builds

### Why should this Pull Request be merged?

Fix #186 

### What testing has been done?

- [Ran a pipeline](https://ni.visualstudio.com/DevCentral/_build/results?buildId=4949729&view=logs&j=3bd4616a-ba05-5ecb-8884-5259017d0dbc&t=775180f8-36b4-5115-ef4b-6792bea0af0b) of Scan Engine Modules release/23.5 using commit f60ee9eaf28e2b1372424724d76385d3a081fbbd
- Pending PR build of this repo