### PR TITLE
Remove existing files check

### DIFF
--- a/azure-templates/powershell-scripts/packaging/copy-payload.ps1
+++ b/azure-templates/powershell-scripts/packaging/copy-payload.ps1
@@ -26,11 +26,10 @@ Else
     If (Test-Path "$bitnessSpecificPath")
     {
       Write-Output "copying payload from `"$bitnessSpecificPath`" into nipkg/data install directory..."
-      Copy-Item -Recurse `
+      Copy-Item -Recurse -Force `
         -Path "$bitnessSpecificPath\*" `
-        -Destination "$env:CD_NIPKG_PATH\data\$installDir" `
-        -Force
-      }
+        -Destination "$env:CD_NIPKG_PATH\data\$installDir"
+    }
     Else
     {
       Write-Output "no payload at `"$bitnessSpecificPath`" so skipping that location."

--- a/azure-templates/powershell-scripts/packaging/copy-payload.ps1
+++ b/azure-templates/powershell-scripts/packaging/copy-payload.ps1
@@ -26,11 +26,9 @@ Else
     If (Test-Path "$bitnessSpecificPath")
     {
       Write-Output "copying payload from `"$bitnessSpecificPath`" into nipkg/data install directory..."
-      $existingItems = Get-ChildItem -Recurse "$env:CD_NIPKG_PATH\data\$installDir"
       Copy-Item -Recurse `
         -Path "$bitnessSpecificPath\*" `
-        -Destination "$env:CD_NIPKG_PATH\data\$installDir" `
-        -Exclude $existingItems
+        -Destination "$env:CD_NIPKG_PATH\data\$installDir"
     }
     Else
     {

--- a/azure-templates/powershell-scripts/packaging/copy-payload.ps1
+++ b/azure-templates/powershell-scripts/packaging/copy-payload.ps1
@@ -28,8 +28,9 @@ Else
       Write-Output "copying payload from `"$bitnessSpecificPath`" into nipkg/data install directory..."
       Copy-Item -Recurse `
         -Path "$bitnessSpecificPath\*" `
-        -Destination "$env:CD_NIPKG_PATH\data\$installDir"
-    }
+        -Destination "$env:CD_NIPKG_PATH\data\$installDir" `
+        -Force
+      }
     Else
     {
       Write-Output "no payload at `"$bitnessSpecificPath`" so skipping that location."


### PR DESCRIPTION
- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-custom-device-build-tools/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Not sure what this was originally for (I imagine it was to facilitate some duplicate files in the build-tools tests), but instead of skipping files, just force overwrites them.

### Why should this Pull Request be merged?

Currently some of scan engine's files are being skipped.

### What testing has been done?

Ran this with SEECD and the files that were missing are now included:
![image](https://github.com/ni/niveristand-custom-device-build-tools/assets/42351034/4177d731-322d-48c1-bab9-5be2ebdb200b)
