### PR TITLE
Add error when a dev branch dep is missing

### DIFF
--- a/azure-templates/powershell-scripts/dependency-setup.ps1
+++ b/azure-templates/powershell-scripts/dependency-setup.ps1
@@ -71,6 +71,10 @@ Else
       -Path "$env:CD_WORKSPACE\$env:CD_REPOSITORY\$destination" `
       -ItemType 'Directory'
   }
+  If ($dependencyFilePath -eq "")
+  {
+    Write-Error "None of the build outputs in `"$branchName`" have a valid build with .finished tag."
+  }
   If (Test-Path $dependencyFilePath)
   {
     Copy-Item `

--- a/azure-templates/powershell-scripts/dependency-setup.ps1
+++ b/azure-templates/powershell-scripts/dependency-setup.ps1
@@ -73,7 +73,7 @@ Else
   }
   If ($dependencyFilePath -eq "")
   {
-    Write-Error "None of the build outputs in `"$branchName`" have a valid build with .finished tag."
+    Write-Error "None of the build outputs in `"$branchName`" have a valid build with .finished tag.  Dependency could not be found."
   }
   If (Test-Path $dependencyFilePath)
   {


### PR DESCRIPTION
- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-custom-device-build-tools/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

When a branch builds, it will search for dependencies in dev branches of the same name first before defaulting to main.  This leaves the possibility with simultaneous build kickoffs that no existing .finished branch exists.  We should throw a meaningful error in this case.

### Why should this Pull Request be merged?

Throws an error that hopefully doesn't require digging into the code to troubleshoot.

### What testing has been done?

This is what shows currently:
![image](https://github.com/ni/niveristand-custom-device-build-tools/assets/42351034/6cd3edbf-d050-4f0f-ab6a-52996edf1e6f)

