### PR TITLE
Update readme about archiving Jenkins support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # NI VeriStand Custom Device Build Tools
 The **niveristand-custom-device-build-tools** repository provides a common set of tools to automate building NI VeriStand custom devices using the [Jenkins automation server](https://jenkins.io/). The intended audience includes custom device developers and integrators.
 
+## Jenkins Branch Archive
+The [main branch](https://github.com/ni/niveristand-custom-device-build-tools/tree/main) of this repository has been updated to support Azure Pipelines. This branch contains the build pipeline steps for Jenkins automation, and will no longer be actively updated for new versions of VeriStand.
+
 ## Usage
 Two files are required in order to use this pipeline for a given repository, a `Jenkinsfile` and a `build.toml` file. Additionally, the pipeline assumes each executor node on the Jenkins server is tagged with certain labels.
 


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-custom-device-build-tools/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Update readme about archiving Jenkins support

### Why should this Pull Request be merged?

I created a `jenkins` branch to archive builds support for Jenkins based on the 54320887d68d369781e1539563d6fbd0d8a68714 commit before Azure pipeline updates were made (plus cherry-picking the relevant change from 72f20e7771eacb1081bee239aeef540563c1434c). This branch needs updated with this disclaimer, as well as getting added write protection to avoid PR-less pushes.

### What testing has been done?

None
