### PR TITLE
Update readme to remove Jenkins and add Azure Pipelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,60 +1,11 @@
 # NI VeriStand Custom Device Build Tools
-The **niveristand-custom-device-build-tools** repository provides a common set of tools to automate building NI VeriStand custom devices using the [Jenkins automation server](https://jenkins.io/). The intended audience includes custom device developers and integrators.
+The **niveristand-custom-device-build-tools** repository provides a common set of tools to automate building NI VeriStand custom devices using [Azure Pipelines](https://azure.microsoft.com/en-us/products/devops/pipelines). The intended audience includes custom device developers and integrators.
 
 ## Jenkins Branch Archive
 The main branch of this repository has been updated to support Azure Pipelines. The [jenkins branch](https://github.com/ni/niveristand-custom-device-build-tools/tree/jenkins) contains the build pipeline steps for Jenkins automation, and will no longer be actively updated for new versions of VeriStand.
 
 ## Usage
-Two files are required in order to use this pipeline for a given repository, a `Jenkinsfile` and a `build.toml` file. Additionally, the pipeline assumes each executor node on the Jenkins server is tagged with certain labels.
-
-### Node Labels
-Each node capable of building a custom device must have the label *'veristand'* and a label for each version of LabVIEW/VeriStand installed.
-A node that is capable of building a custom device for VeriStand 2019 and 2020 would have the labels `vs_cd_build`, `2019`, and `2020`.
-
-### Jenkinsfile
-The pipeline is used by a `Jenkinsfile` defined in other repositories in this organization.
-
-The Jenkins server must be configured to load this library implicitly, either by the Jenkins Pipeline Global Library or as a Shared Pipeline Library within a job folder. To build a custom device for LabVIEW/VeriStand 2019 and 2020 using the 32-bit LabVIEW runtime and LabVIEW/VeriStand 2021 using the 64-bit LabVIEW runtime if the library name configured in Jenkins is `vs-build-tools`:
-
-```groovy
-// Jenkinsfile
-@Library('vs-build-tools') _
-def lvVersions = [
-  32 : ['2019', '2020'],
-  64 : ['2021']
-]
-ni.vsbuild.PipelineExecutor.execute(this, lvVersions)
-```
-
-#### Build-Time Dependencies
-Some custom devices require builds of multiple repositories. This system allows a Jenkinsfile for one repository to specify a dependency on other repositories. Dependencies will be built before the pipeline for the top-level repository. Dependencies are an optional parameter to the `PipelineExecutor.execute()` method:
-
-```groovy
-// Jenkinsfile snippet
-List<String> dependencies = ['dep1', 'dep2']
-ni.vsbuild.PipelineExecutor.execute(this, lvVersions, dependencies)
-```
-
-### build.toml
-The `build.toml` file defines the pipeline configuration and stages used during the build.
-
-For a custom device that has only one LabVIEW project and simply needs to build every build spec in that project, the `build.toml` file will be fairly simple:
-
-```
-[archive]
-build_output_dir = 'Built'
-archive_location = 'C:\MyCustomDevice'
-
-[projects.cd]
-path = 'Source\MyCustomDevice.lvproj'
-
-[[build.steps]]
-name = 'Build My Custom Device'
-type = 'lvBuildAll'
-project = '{cd}'
-```
-
-Stages are ordered by the pipeline. Steps within the codegen and build stages are executed in the top to bottom order specified in `build.toml`. For a complete description of the available TOML configuration options, see the [build.toml specification](docs/Toml%20Help.md).
+The azure-pipelines.yaml file contains the configuration for builds using the stages defined in this repo. See the [documentation](https://github.com/ni/niveristand-custom-device-build-tools/blob/main/add-docs/docs/Azure%20Pipeline%20YAML.md) for supported properties.
 
 ## LabVIEW Version
 The LabVIEW source for this repository is saved for LabVIEW 2020, but is forward compatible to newer versions.
@@ -64,13 +15,7 @@ The following top-level dependencies are required on the build machine to use th
 
 - [LabVIEW Professional Development System](http:/ni.com/labview)
 - [LabVIEW Command Line Interface](http://www.ni.com/en-us/support/downloads/software-products/download.ni-labview-command-line-interface.html)
-- [Python](https://www.python.org/downloads/) (Version 3.6.3 or later)
-
-The following plugins are required on the Jenkins server:
-
-- [Pipeline Plugin](https://wiki.jenkins.io/display/JENKINS/Pipeline+Plugin)
-- [Pipeline Utility Steps Plugin](https://wiki.jenkins.io/display/JENKINS/Pipeline+Utility+Steps+Plugin)
-- [GitHub Branch Source Plugin](https://wiki.jenkins.io/display/JENKINS/GitHub+Branch+Source+Plugin)
+- [Python](https://www.python.org/downloads/) (Version 3.7 or later)
 
 ## Git History & Rebasing Policy
 Branch rebasing and other history modifications will be listed here, with several notable exceptions:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # NI VeriStand Custom Device Build Tools
 The **niveristand-custom-device-build-tools** repository provides a common set of tools to automate building NI VeriStand custom devices using the [Jenkins automation server](https://jenkins.io/). The intended audience includes custom device developers and integrators.
 
+## Jenkins Branch Archive
+The main branch of this repository has been updated to support Azure Pipelines. The [jenkins branch](https://github.com/ni/niveristand-custom-device-build-tools/tree/jenkins) contains the build pipeline steps for Jenkins automation, and will no longer be actively updated for new versions of VeriStand.
+
 ## Usage
 Two files are required in order to use this pipeline for a given repository, a `Jenkinsfile` and a `build.toml` file. Additionally, the pipeline assumes each executor node on the Jenkins server is tagged with certain labels.
 


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-custom-device-build-tools/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Update readme to remove Jenkins and add Azure Pipelines

### Why should this Pull Request be merged?

Jenkins support has been archived in the `jenkins` branch. We do not need this info in the readme in main.
I also paired down the user guide info from the readme and instead link to the docs getting added in #169

### What testing has been done?

None
