### PR TITLE
add a major version to support DSF control file

### DIFF
--- a/azure-templates/powershell-scripts/packaging/stage-directories.ps1
+++ b/azure-templates/powershell-scripts/packaging/stage-directories.ps1
@@ -33,7 +33,7 @@ Else
     -replace "{display_version}", "$env:CD_RELEASE_VERSION" `
     -replace "{quarterly_display_version}", "$env:CD_RELEASE_QUARTERLY" `
     -replace "{labview_short_version}", "$env:CD_LABVIEW_SHORTVERSION" `
-    -replace "{major_version}", "$env:CD_LABVEW_SHORTVERSION" `
+    -replace "{major_version}", "$env:CD_LABVIEW_SHORTVERSION" `
     -replace "{pkg_x86_bitness_suffix}", "$env:CD_NIPKG_X86SUFFIX"
   Write-Output $contents
   Set-Content -Value $contents -Path "$env:CD_NIPKG_PATH\control\control"

--- a/azure-templates/powershell-scripts/packaging/stage-directories.ps1
+++ b/azure-templates/powershell-scripts/packaging/stage-directories.ps1
@@ -33,6 +33,7 @@ Else
     -replace "{display_version}", "$env:CD_RELEASE_VERSION" `
     -replace "{quarterly_display_version}", "$env:CD_RELEASE_QUARTERLY" `
     -replace "{labview_short_version}", "$env:CD_LABVIEW_SHORTVERSION" `
+    -replace "{major_version}", "$env:CD_LABVEW_SHORTVERSION" `
     -replace "{pkg_x86_bitness_suffix}", "$env:CD_NIPKG_X86SUFFIX"
   Write-Output $contents
   Set-Content -Value $contents -Path "$env:CD_NIPKG_PATH\control\control"

--- a/test-build/control-a
+++ b/test-build/control-a
@@ -12,5 +12,5 @@ XB-UserVisible: yes
 Section: Add-Ons
 XB-DisplayVersion: {quarterly_display_version}
 XB-DisplayName: Test Package for VeriStand {veristand_version}
-Depends: ni-veristand-{labview_version} (>= {labview_short_version}.0.0), ni-switch (>= 20.0.0)
+Depends: ni-veristand-{labview_version} (>= {labview_short_version}.0.0), ni-switch (>= {major_version}.0.0)
 Recommends: ni-switch-veristand-{veristand_version}-labview-support (>= {display_version}), ni-switch-veristand-{veristand_version}-labview-examples (>= {display_version})


### PR DESCRIPTION
- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-custom-device-build-tools/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

adds "major version" to support the DSF control file: 
https://github.com/ni/niveristand-data-sharing-framework-custom-device-plugins/blob/5feaad540ca53969f3dbd1c79c811c0a3a14c0ea/control_dsf_plugins#L15C163-L15C163

### Why should this Pull Request be merged?

We need this working by the next release of DSF at the end of the cycle

### What testing has been done?

Built DSF off of this branch of build-tools:

![image](https://github.com/ni/niveristand-custom-device-build-tools/assets/42351034/674efb70-c20e-49bf-acbd-ba4704c9fc1f)
