### PR TITLE
Fix major_version substitution

### DIFF
--- a/azure-templates/powershell-scripts/define-build-variables.ps1
+++ b/azure-templates/powershell-scripts/define-build-variables.ps1
@@ -18,6 +18,7 @@ Write-Host "##vso[task.setvariable variable=CD.Nipkg.Path]$env:CD_REPOSITORY\nip
 # Set release information
 Write-Output "Determining quarterly release version..."
 $releaseData = "$releaseVersion" -Split "\."
+$majorVersion = $releaseData[0]
 If ($releaseData[1] -eq "0")
 {
     $derivedQuarterlyReleaseVersion = "20$($releaseData[0]) Q1"
@@ -41,6 +42,7 @@ If (-not($derivedQuarterlyReleaseVersion -match "20.*Q.*"))
 Write-Output "Configuring release version to `"$releaseVersion`" and quarterly release version to `"$derivedQuarterlyReleaseVersion`"..."
 Write-Host "##vso[task.setvariable variable=CD.Release.Version]$releaseVersion"
 Write-Host "##vso[task.setvariable variable=CD.Release.Quarterly]$derivedQuarterlyReleaseVersion"
+Write-Host "##vso[task.setvariable variable=CD.Release.MajorVersion]$majorVersion"
 
 # Set LabVIEW version information
 Write-Host "##vso[task.setvariable variable=CD.LabVIEW.Version]$lvVersion"

--- a/azure-templates/powershell-scripts/packaging/stage-directories.ps1
+++ b/azure-templates/powershell-scripts/packaging/stage-directories.ps1
@@ -33,7 +33,7 @@ Else
     -replace "{display_version}", "$env:CD_RELEASE_VERSION" `
     -replace "{quarterly_display_version}", "$env:CD_RELEASE_QUARTERLY" `
     -replace "{labview_short_version}", "$env:CD_LABVIEW_SHORTVERSION" `
-    -replace "{major_version}", "$env:CD_LABVIEW_SHORTVERSION" `
+    -replace "{major_version}", "$env:CD_RELEASE_MAJORVERSION" `
     -replace "{pkg_x86_bitness_suffix}", "$env:CD_NIPKG_X86SUFFIX"
   Write-Output $contents
   Set-Content -Value $contents -Path "$env:CD_NIPKG_PATH\control\control"


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-custom-device-build-tools/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Fixes the `{major_version}` substitution to return the major version and not the LabVIEW short version.

### Why should this Pull Request be merged?

I missed this while reviewing #195.

### What testing has been done?

TODO: Detail what testing has been done to ensure this submission meets requirements.
