### PR TITLE
Require that the VeriStand agent capability is "True"

### DIFF
--- a/azure-templates/stages.yml
+++ b/azure-templates/stages.yml
@@ -80,7 +80,7 @@ stages:
     condition: and(eq(variables['Build.Reason'], 'PullRequest'), eq('${{ parameters.disableDiff }}', false))
     pool:
       name: ${{ parameters.pool }}
-      demands: VeriStand${{ parameters.lvVersionToDiff }}
+      demands: VeriStand${{ parameters.lvVersionToDiff }} -equals True
     jobs:
       - job: DiffVIsforPR
         displayName: Diff VIs for PR
@@ -110,7 +110,7 @@ stages:
         - job: Job_Build_${{ item.version }}_${{ item.bitness }}
           pool:
             name: ${{ parameters.pool }}
-            demands: VeriStand${{ item.version }}
+            demands: VeriStand${{ item.version }} -equals True
           displayName: Build LabVIEW ${{ item.version }} ${{ item.bitness }}
           timeoutInMinutes: 120
           steps:


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-custom-device-build-tools/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Require that the version-based agent capability has a value of "True", to make it easier to disable a version for a particular agent.

### Why should this Pull Request be merged?

It's challenging to remove an agent capability through the web interface but easy to override or add new ones.

### What testing has been done?

PR build.
