### PR TITLE
Include patch version in the quarterly display string

### DIFF
--- a/azure-templates/powershell-scripts/define-build-variables.ps1
+++ b/azure-templates/powershell-scripts/define-build-variables.ps1
@@ -25,7 +25,7 @@ If ($releaseData[1] -eq "0")
 }
 If ($releaseData[1] -eq "3")
 {
-$derivedQuarterlyReleaseVersion = "20$($releaseData[0]) Q2"
+    $derivedQuarterlyReleaseVersion = "20$($releaseData[0]) Q2"
 }
 If ($releaseData[1] -eq "5")
 {
@@ -34,6 +34,10 @@ If ($releaseData[1] -eq "5")
 If ($releaseData[1] -eq "8")
 {
     $derivedQuarterlyReleaseVersion = "20$($releaseData[0]) Q4"
+}
+If ($releaseData[2] -ne "0")
+{
+    $derivedQuarterlyReleaseVersion = "$($derivedQuarterlyReleaseVersion) Patch $($releaseData[2])"
 }
 If (-not($derivedQuarterlyReleaseVersion -match "20.*Q.*"))
 {


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-custom-device-build-tools/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Include the patch version in the display string, e.g. 23.8.1 renders as `2023 Q4 Patch 1`.

### Why should this Pull Request be merged?

Provide a way to distinguish patch builds from the initial one.

### What testing has been done?

TODO