### PR TITLE
Update regex to include controls in VI diffs

### DIFF
--- a/resources/labview_diff.py
+++ b/resources/labview_diff.py
@@ -101,8 +101,8 @@ def get_changed_labview_files(target_ref):
     """
     changed_files = git_utilities.get_changed_files(target_ref)
 
-    # https://regex101.com/r/W3riqw/1
-    diff_regex = re.compile(r"^(.*\.vi[tm]?)$", re.MULTILINE)
+    # https://regex101.com/r/ZiBEXa/1
+    diff_regex = re.compile(r"^(.*\.(?:vi|vim|vit|ctl))$", re.MULTILINE)
 
     for status, filename in changed_files:
         if re.match(diff_regex, filename):


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-custom-device-build-tools/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Update regex to include controls  in VI diffs

### Why should this Pull Request be merged?

Custom Devices store lots of useful information in controls. This change adds diffs of controls to the comments posted on PRs.

### What testing has been done?

Locally tested to see diffs of .ctl files
