### PR TITLE
Remove 2020 from test build

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -21,8 +21,6 @@ stages:
 
 # Test Versions - At least 1 of each supported LabVIEW version and 1 of each bitness
       lvVersionsToBuild:
-        - version: '2020'
-          bitness: '32bit'
         - version: '2021'
           bitness: '32bit'
         - version: '2021'


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-custom-device-build-tools/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Stops trying to create a test build for LV 2020.

### Why should this Pull Request be merged?

LabVIEW/VeriStand 2020 are no longer supported.

### What testing has been done?

PR build.
