### PR TITLE
Add pool and demands to packaging step to ensure specific agents

### DIFF
--- a/azure-templates/stages.yml
+++ b/azure-templates/stages.yml
@@ -140,6 +140,9 @@ stages:
 
         # Packaging Jobs
       - job: Job_Package_All
+        pool:
+          name: ${{ parameters.pool }}
+          demands: VeriStand${{ parameters.lvVersionToDiff }} -equals True
         dependsOn:
           - ${{ each item in parameters.lvVersionsToBuild }}:
             - Job_Build_${{ item.version }}_${{ item.bitness }}


### PR DESCRIPTION
- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-custom-device-build-tools/blob/main/CONTRIBUTING.md).

TODO: Check the above box with an 'x' indicating you've read and followed [CONTRIBUTING.md](https://github.com/ni/niveristand-custom-device-build-tools/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

This change ensure that the packaging job uses an agent from the desired pool and with the desired capability similar to others steps in the stages.yml file.

### Why should this Pull Request be merged?

The lack of a pool and demands section in the packaging job open up the step to running on a undesired agent when specifying a pool other than DevCentral-VeriStand-CustomDevices. Specifically, the ADG System R&D team uses their own pool of agents and were encountering an issue where the packaging job would choose an agent other than the ones they'd like to use that are in the same pool but not owned by our team. This fixes the issue while retaining the expected behavior when the VeriStand team runs this build tool on their agent pool.

### What testing has been done?

I forked the build tools repo and made these changes to it, ran a custom device build pipeline using that fork, and the run was successful. Here is the link: https://dev.azure.com/ni/DevCentral/_build/results?buildId=9537391&view=results
