### PR TITLE
Drop 2021, Add 2025

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -21,10 +21,6 @@ stages:
 
 # Test Versions - At least 1 of each supported LabVIEW version and 1 of each bitness
       lvVersionsToBuild:
-        - version: '2021'
-          bitness: '32bit'
-        - version: '2021'
-          bitness: '64bit'
         - version: '2023'
           bitness: '32bit'
         - version: '2023'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -33,6 +33,10 @@ stages:
           bitness: '32bit'
         - version: '2024'
           bitness: '64bit'
+        - version: '2025'
+          bitness: '32bit'
+        - version: '2025'
+          bitness: '64bit'
 
 # Test Dependencies - multiple dependencies that are expected in the build steps below this
       dependencies:
@@ -96,7 +100,7 @@ stages:
           target: 'This value does not matter'
           buildSpec: 'This value does not matter'
 
-      releaseVersion: '24.0.0'
+      releaseVersion: '25.0.0'
       buildOutputLocation: 'test-build\Built'
       archiveLocation: '\\nirvana\Measurements\VeriStandAddons\prototype\niveristand-custom-device-build-tools\complexCase'
 
@@ -127,6 +131,6 @@ stages:
           target: 'My Computer'
           buildSpec: 'EmptySpec'
 
-      releaseVersion: '24.0.0'
+      releaseVersion: '25.0.0'
       buildOutputLocation: 'test-build\Built'
       archiveLocation: '\\nirvana\Measurements\VeriStandAddons\prototype\niveristand-custom-device-build-tools\emptyCase'

--- a/azure-templates/powershell-scripts/define-build-variables.ps1
+++ b/azure-templates/powershell-scripts/define-build-variables.ps1
@@ -90,7 +90,7 @@ Elseif ("$lvVersion" -eq "2025")
 }
 Else
 {
-    Write-Error "Invalid LabVIEW version defined in pipeline.  Use either 2020, 2021, 2023, or 2024."
+    Write-Error "Invalid LabVIEW version defined in pipeline.  Use either 2020, 2021, 2023, 2024 or 2025"
 }
 
 # Set LabVIEW Bitness information

--- a/azure-templates/powershell-scripts/define-build-variables.ps1
+++ b/azure-templates/powershell-scripts/define-build-variables.ps1
@@ -81,6 +81,13 @@ Elseif ("$lvVersion" -eq "2024")
     Write-Host "##vso[task.setvariable variable=CD.LabVIEW.ShortVersion]24"
     Write-Host "##vso[task.setvariable variable=CD.LabVIEW.SupportPackageSuffix]labview-support"
 }
+Elseif ("$lvVersion" -eq "2025")
+{
+    Write-Output "Setting variables for LabVIEW 2025..."
+    Write-Host "##vso[task.setvariable variable=CD.LabVIEW.Config]12.0.0.0"
+    Write-Host "##vso[task.setvariable variable=CD.LabVIEW.ShortVersion]25"
+    Write-Host "##vso[task.setvariable variable=CD.LabVIEW.SupportPackageSuffix]labview-support"
+}
 Else
 {
     Write-Error "Invalid LabVIEW version defined in pipeline.  Use either 2020, 2021, 2023, or 2024."

--- a/azure-templates/powershell-scripts/define-build-variables.ps1
+++ b/azure-templates/powershell-scripts/define-build-variables.ps1
@@ -53,21 +53,7 @@ Write-Host "##vso[task.setvariable variable=CD.LabVIEW.Version]$lvVersion"
 Write-Host "##vso[task.setvariable variable=lvVersion]$lvVersion" # Keep legacy version for variables used in packaging
 # When adding a new version of LabVIEW as an option in custom device pipelines, 
 # a new If statement is needed below with relevant variables
-If ("$lvVersion" -eq "2020")
-{
-    Write-Output "Setting variables for LabVIEW 2020..."
-    Write-Host "##vso[task.setvariable variable=CD.LabVIEW.Config]8.0.0.0"
-    Write-Host "##vso[task.setvariable variable=CD.LabVIEW.ShortVersion]20"
-    Write-Host "##vso[task.setvariable variable=CD.LabVIEW.SupportPackageSuffix]labview-2020-support{pkg_x86_bitness_suffix}"
-}
-Elseif ("$lvVersion" -eq "2021")
-{
-    Write-Output "Setting variables for LabVIEW 2021..."
-    Write-Host "##vso[task.setvariable variable=CD.LabVIEW.Config]9.0.0.0"
-    Write-Host "##vso[task.setvariable variable=CD.LabVIEW.ShortVersion]21"
-    Write-Host "##vso[task.setvariable variable=CD.LabVIEW.SupportPackageSuffix]labview-2021-support{pkg_x86_bitness_suffix}"
-}
-Elseif ("$lvVersion" -eq "2023")
+if ("$lvVersion" -eq "2023")
 {
     Write-Output "Setting variables for LabVIEW 2023..."
     Write-Host "##vso[task.setvariable variable=CD.LabVIEW.Config]10.0.0.0"
@@ -90,7 +76,7 @@ Elseif ("$lvVersion" -eq "2025")
 }
 Else
 {
-    Write-Error "Invalid LabVIEW version defined in pipeline.  Use either 2020, 2021, 2023, 2024 or 2025"
+    Write-Error "Invalid LabVIEW version defined in pipeline.  Use either 2023, 2024 or 2025"
 }
 
 # Set LabVIEW Bitness information

--- a/azure-templates/stages.yml
+++ b/azure-templates/stages.yml
@@ -28,11 +28,11 @@ parameters:
   - name: lvVersionsToBuild
     type: object
     default:
-      - version: '2021'
-        bitness: '64bit'
       - version: '2023'
         bitness: '64bit'
       - version: '2024'
+        bitness: '64bit'
+      - version: '2025'
         bitness: '64bit'
 
   # codegenVis (optional): string array of codegen VI paths

--- a/docs/Azure Pipeline YAML.md
+++ b/docs/Azure Pipeline YAML.md
@@ -36,7 +36,7 @@ The currently available parameters are listed in the table below.  Examples of u
 | Parameter Name | Required? | Type | Supported Values |
 | --- | --- | --- | --- |
 | `lvVersionsToBuild` | Yes | Nested Sequence | 1 or more Named Sequences containing elements `version` and `bitness` |
-| →`version` | Yes | String | '2021', '2023', '2024' or '2025' |
+| →`version` | Yes | String | '2023', '2024' or '2025' |
 | →`bitness` | Yes | String | '32bit', '64bit' |
 | `codegenVis` | No | Sequence | 1 or more relative paths to VIs that need to be run before any `buildSteps` are performed |
 | `dependencies` | No | Nested Sequence | 1 or more Named Sequences containing elements `source`, `file`, and `destination` defining dependencies that need to be copied to the specified destination before each `buildStep` |

--- a/docs/Azure Pipeline YAML.md
+++ b/docs/Azure Pipeline YAML.md
@@ -36,7 +36,7 @@ The currently available parameters are listed in the table below.  Examples of u
 | Parameter Name | Required? | Type | Supported Values |
 | --- | --- | --- | --- |
 | `lvVersionsToBuild` | Yes | Nested Sequence | 1 or more Named Sequences containing elements `version` and `bitness` |
-| →`version` | Yes | String | '2020', '2021', '2023', or '2024' |
+| →`version` | Yes | String | '2023', '2024' or '2025' |
 | →`bitness` | Yes | String | '32bit', '64bit' |
 | `codegenVis` | No | Sequence | 1 or more relative paths to VIs that need to be run before any `buildSteps` are performed |
 | `dependencies` | No | Nested Sequence | 1 or more Named Sequences containing elements `source`, `file`, and `destination` defining dependencies that need to be copied to the specified destination before each `buildStep` |

--- a/docs/Azure Pipeline YAML.md
+++ b/docs/Azure Pipeline YAML.md
@@ -36,7 +36,7 @@ The currently available parameters are listed in the table below.  Examples of u
 | Parameter Name | Required? | Type | Supported Values |
 | --- | --- | --- | --- |
 | `lvVersionsToBuild` | Yes | Nested Sequence | 1 or more Named Sequences containing elements `version` and `bitness` |
-| →`version` | Yes | String | '2023', '2024' or '2025' |
+| →`version` | Yes | String | '2021', '2023', '2024' or '2025' |
 | →`bitness` | Yes | String | '32bit', '64bit' |
 | `codegenVis` | No | Sequence | 1 or more relative paths to VIs that need to be run before any `buildSteps` are performed |
 | `dependencies` | No | Nested Sequence | 1 or more Named Sequences containing elements `source`, `file`, and `destination` defining dependencies that need to be copied to the specified destination before each `buildStep` |

--- a/test-build/dependency-builder/Readme.md
+++ b/test-build/dependency-builder/Readme.md
@@ -6,4 +6,4 @@ and
 
 These dependencies are used in the test-build that is run when changes are committed to niveristand-custom-device-build-tools to test codepaths that search for dependencies.
 
-To build the dependencies, you can use dependency-builder.bat on a system with LabVIEW 2020, LabVIEW 2021, LabVIEW 2023, LabVIEW 2024, and LabVIEW2025.  It will generate exports in dependency-test that can be copied into nirvana as desired.
+To build the dependencies, you can use dependency-builder.bat on a system with LabVIEW 2023, LabVIEW 2024, and LabVIEW2025.  It will generate exports in dependency-test that can be copied into nirvana as desired.

--- a/test-build/dependency-builder/Readme.md
+++ b/test-build/dependency-builder/Readme.md
@@ -6,4 +6,4 @@ and
 
 These dependencies are used in the test-build that is run when changes are committed to niveristand-custom-device-build-tools to test codepaths that search for dependencies.
 
-To build the dependencies, you can use dependency-builder.bat on a system with LabVIEW 2020, LabVIEW 2021, and LabVIEW 2023.  It will generate exports in dependency-test that can be copied into nirvana as desired.
+To build the dependencies, you can use dependency-builder.bat on a system with LabVIEW 2020, LabVIEW 2021, LabVIEW 2023, LabVIEW 2024, and LabVIEW2025.  It will generate exports in dependency-test that can be copied into nirvana as desired.


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-custom-device-build-tools/blob/main/CONTRIBUTING.md).

TODO: Check the above box with an 'x' indicating you've read and followed [CONTRIBUTING.md](https://github.com/ni/niveristand-custom-device-build-tools/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Remove 2021 and Adds initial support for LabVIEW and VeriStand 2025.

### Why should this Pull Request be merged?

needed for building other github [CDs] repo.
Needed for a future release.

### What testing has been done?

PR build
