### PR TITLE
Added preBuildScript to add custom script just before running the build

### DIFF
--- a/azure-templates/stages.yml
+++ b/azure-templates/stages.yml
@@ -70,6 +70,12 @@ parameters:
     type: string
   - name: archiveLocation
     type: string
+    
+  # preBuildScript (optional): inline script to run before build
+  - name: preBuildScript
+    type: string
+    default: ''
+
 
 # Note: If custom build steps are needed for a particular custom device, copy this entire template into the azure-pipeline and add steps before/after as needed
 stages:
@@ -121,6 +127,13 @@ stages:
                 buildOutputLocation: ${{ parameters.buildOutputLocation }}
                 codegenVis:          ${{ parameters.codegenVis }}
                 submodules:          ${{ parameters.submodules }}
+                
+            - ${{ if ne(parameters.preBuildScript, '') }}:
+              - task: PowerShell@2
+                displayName: Run Custom Script Before Build
+                inputs:
+                  targetType: 'inline'
+                  script: ${{ parameters.preBuildScript }}
 
             - ${{ if ne( parameters.buildSteps, '' )}}:
               - ${{ each buildStep in parameters.buildSteps }}:


### PR DESCRIPTION
- [ ] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-custom-device-build-tools/blob/main/CONTRIBUTING.md).

TODO: Check the above box with an 'x' indicating you've read and followed [CONTRIBUTING.md](https://github.com/ni/niveristand-custom-device-build-tools/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Adds a preBuildScript that can be used to run custom script before build.

### Why should this Pull Request be merged?

It will help other custom devices which uses the template "stages.yml" to get a feature of running their own script before build.

### What testing has been done?

Using PR Build
