### PR TITLE
Automated pipeline to run on daily bases

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -13,6 +13,13 @@ resources:
       endpoint:   nivs-custom-devices
       name:       ni/niveristand-custom-device-build-tools
 
+schedules:
+- cron: '0 0 * * *'
+  displayName: Daily midnight build
+  branches:
+    include:
+    - main
+
 stages:
   - template: azure-templates/stages.yml
     parameters:


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-custom-device-build-tools/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

This PR schedules the niveristand-custom-device-build-tools pipeline to run automatically every day at 12:00 AM.

### Why should this Pull Request be merged?

To automatically trigger the pipeline.

### What testing has been done?

NA
