### PR TITLE
Updated pipeline schedule to 6PM IST

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -14,8 +14,8 @@ resources:
       name:       ni/niveristand-custom-device-build-tools
 
 schedules:
-- cron: '0 0 * * *'
-  displayName: Daily midnight build
+- cron: '30 12 * * *'
+  displayName: Daily 6 PM (IST) build
   branches:
     include:
     - main


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-custom-device-build-tools/blob/main/CONTRIBUTING.md).

## What does this Pull Request accomplish?
This PR schedules the niveristand-custom-device-build-tools pipeline to run automatically every day at 6:00 PM IST.

## Why should this Pull Request be merged?
To automatically trigger the pipeline.

## What testing has been done?
NA
