### PR TITLE
[Temp] Restrict picking linux agent for any buid stage of custom devices [cd windows build]

### DIFF
--- a/azure-templates/stages.yml
+++ b/azure-templates/stages.yml
@@ -78,7 +78,9 @@ stages:
     condition: and(eq(variables['Build.Reason'], 'PullRequest'), eq('${{ parameters.disableDiff }}', false))
     pool:
       name: ${{ parameters.pool }}
-      demands: VeriStand${{ parameters.lvVersionToDiff }} -equals True
+      demands: 
+        - VeriStand${{ parameters.lvVersionToDiff }} -equals True
+        - agent.os -equals Windows_NT
     jobs:
       - job: DiffVIsforPR
         displayName: Diff VIs for PR
@@ -108,7 +110,9 @@ stages:
         - job: Job_Build_${{ item.version }}_${{ item.bitness }}
           pool:
             name: ${{ parameters.pool }}
-            demands: VeriStand${{ item.version }} -equals True
+            demands: 
+              - VeriStand${{ item.version }} -equals True
+              - agent.os -equals Windows_NT
           displayName: Build LabVIEW ${{ item.version }} ${{ item.bitness }}
           timeoutInMinutes: 120
           steps:
@@ -142,7 +146,9 @@ stages:
       - job: Job_Package_All
         pool:
           name: ${{ parameters.pool }}
-          demands: VeriStand${{ parameters.lvVersionToDiff }} -equals True
+          demands: 
+            - VeriStand${{ parameters.lvVersionToDiff }} -equals True
+            - agent.os -equals Windows_NT
         dependsOn:
           - ${{ each item in parameters.lvVersionsToBuild }}:
             - Job_Build_${{ item.version }}_${{ item.bitness }}


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-custom-device-build-tools/blob/main/CONTRIBUTING.md).

TODO: Check the above box with an 'x' indicating you've read and followed [CONTRIBUTING.md](https://github.com/ni/niveristand-custom-device-build-tools/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

We need to restrict the build stage of any custom device to pick up linux agent [newly created]. 
This restriction is required until we are at a stage where we can build any CD on linux agent.

### Why should this Pull Request be merged?

To avoid picking up linux agent by pipeline 

### What testing has been done?

PR build