### PR TITLE
Skipping signing of Linux based files

### DIFF
--- a/azure-templates/powershell-scripts/archive-build.ps1
+++ b/azure-templates/powershell-scripts/archive-build.ps1
@@ -6,7 +6,11 @@ if (-not (Test-Path "$niSignToolPath")) {
 }
 
 $signableExtensions = @('.lvlibp', '.exe', '.dll')
-$filesToSign = Get-ChildItem -Path "$env:CD_BUILDOUTPUTPATH" -Recurse -File | Where-Object { $_.Extension -in $signableExtensions }
+$filesToSign = Get-ChildItem -Path "$env:CD_BUILDOUTPUTPATH" -Recurse -File |
+  Where-Object {
+    $_.Extension -in $signableExtensions -and
+    $_.FullName -notmatch '(?i)\\linux'
+  }
 $failedSignings = @()
 foreach ($file in $filesToSign) {
   Write-Host "Attempting to sign file: $($file.FullName)"


### PR DESCRIPTION
Filter files to sign by excluding those in 'linux' directories.
