### PR TITLE
Use Bash instead of pw for VS CD Build run

### DIFF
--- a/azure-templates/linux-stage.yml
+++ b/azure-templates/linux-stage.yml
@@ -63,23 +63,22 @@ stages:
             timeoutInMinutes: 120
 
             steps:
-              - task: PowerShell@2
+              - task: Bash@3
                 displayName: Build ${{ buildStep.projectLocation }}
                 inputs:
                   targetType: inline
-                  pwsh: true
                   script: |
-                    $projectPath = "$(Build.SourcesDirectory)/${{ buildStep.projectLocation }}"
+                    projectPath="$(Build.SourcesDirectory)/${{ buildStep.projectLocation }}"
 
-                    Write-Host "Project Path: $projectPath"
+                    echo "Project Path: $projectPath"
 
                     # Give LabVIEW enough time to initialize VI Server
-                    Start-Sleep -Seconds 30
+                    sleep 30
 
-                    xvfb-run --auto-servernum LabVIEWCLI `
-                      -LabVIEWPath "/usr/local/natinst/LabVIEW-${{ item.version }}-64/labview" `
-                      -PortNumber 3363 `
-                      -OperationName "${{ buildStep.buildOperation }}" `
-                      -ProjectPath "$projectPath" `
-                      -TargetName "${{ buildStep.target }}" `
+                    xvfb-run --auto-servernum LabVIEWCLI \
+                      -LabVIEWPath "/usr/local/natinst/LabVIEW-${{ item.version }}-64/labview" \
+                      -PortNumber 3363 \
+                      -OperationName "${{ buildStep.buildOperation }}" \
+                      -ProjectPath "$projectPath" \
+                      -TargetName "${{ buildStep.target }}" \
                       -BuildSpecName "${{ buildStep.buildSpec }}"


### PR DESCRIPTION
- [ ] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-custom-device-build-tools/blob/main/CONTRIBUTING.md).

TODO: Check the above box with an 'x' indicating you've read and followed [CONTRIBUTING.md](https://github.com/ni/niveristand-custom-device-build-tools/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Use Bash instead of pw for VS CD Build run

### Why should this Pull Request be merged?

Use Bash instead of pw for VS CD Build run

### What testing has been done?

NA
