### PR TITLE
Remove xvfb to avoid build output cleanup

### DIFF
--- a/azure-templates/linux-stage.yml
+++ b/azure-templates/linux-stage.yml
@@ -119,7 +119,7 @@ stages:
 
                     echo "Starting LabVIEW build..."
 
-                    if xvfb-run --auto-servernum LabVIEWCLI \
+                    if LabVIEWCLI \
                       -LabVIEWPath "/usr/local/natinst/LabVIEW-${{ item.version }}-64/labview" \
                       -PortNumber 3363 \
                       -OperationName "${{ buildStep.buildOperation }}" \
@@ -129,7 +129,7 @@ stages:
                     then
                       echo "LabVIEW build completed successfully."
 
-                      builtFolder="$projectPath/Built"
+                      builtFolder="$(Build.SourcesDirectory)/Built"
 
                       echo "Checking Built folder at: $builtFolder"
 


### PR DESCRIPTION
- [ ] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-custom-device-build-tools/blob/main/CONTRIBUTING.md).

TODO: Check the above box with an 'x' indicating you've read and followed [CONTRIBUTING.md](https://github.com/ni/niveristand-custom-device-build-tools/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Remove xvfb to avoid build output cleanup

### Why should this Pull Request be merged?

Remove xvfb to avoid build output cleanup

### What testing has been done?

NA
