### PR TITLE
Add optional dependsOn parameter to build stage to allow serializing stages

### DIFF
--- a/azure-templates/stages.yml
+++ b/azure-templates/stages.yml
@@ -3,6 +3,12 @@ parameters:
     type: string
     default: Build
 
+  # dependsOn (optional): list of stage names this stage must wait for.
+  # Default [] preserves the existing behavior of starting immediately.
+  - name: dependsOn
+    type: object
+    default: []
+
   - name: disableDiff
     type: boolean
     default: false
@@ -106,7 +112,7 @@ stages:
               lvVersionToDiff: ${{ parameters.lvVersionToDiff }}
 
   - stage: ${{ parameters.stageName }}
-    dependsOn: []
+    dependsOn: ${{ parameters.dependsOn }}
     variables:
       ${{ if ne(variables['Build.Reason'], 'PullRequest')}}:
         CD.BuildCounter: $[counter(format('custom {0}', variables['Build.SourceBranch']), 1)]


### PR DESCRIPTION
- [ ] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-custom-device-build-tools/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Adds a new optional `dependsOn` template parameter to `azure-templates/stages.yml` and
wires it into the main build stage (`- stage: ${{ parameters.stageName }}`).

- New parameter: `dependsOn` (type: `object`, default: `[]`).
- The build stage now uses `dependsOn: ${{ parameters.dependsOn }}` instead of the
  previously hardcoded `dependsOn: []`.

This lets a consuming pipeline declare that one stage must wait for another before
starting (e.g. `dependsOn: [ Build_Classic ]`). The `_DiffVIs` stage is intentionally
left unchanged.


### Why should this Pull Request be merged?

Pipelines that invoke this template more than once (multiple stages on the same agent
pool) currently run those stages in parallel, with no way to serialize them. When two
stages drive LabVIEW on the same agent simultaneously, they collide on the shared VI
Server port (3363), producing intermittent failures:

### What testing has been done?

Pipeline Link: https://dev.azure.com/ni/DevCentral/_build/results?buildId=20008840&view=results
