### PR TITLE
Honor package-level exclusions in packaging stage

### DIFF
--- a/azure-templates/steps-packaging.yml
+++ b/azure-templates/steps-packaging.yml
@@ -6,7 +6,10 @@ parameters:
 
 steps:
   - ${{ each package in parameters.packages }}:
-    - ${{ if ne(package.controlFileName, '') }}:
+    # Skip packaging a package for the current LabVIEW version if that version is listed
+    # in the package's optional "exclusions" (list of {version, bitness}). Packages without
+    # an "exclusions" key are always packaged (convertToJson(null) never matches the version).
+    - ${{ if and(ne(package.controlFileName, ''), not(contains(convertToJson(package.exclusions), format('"version": "{0}"', parameters.lvVersion)))) }}:
       - task: PowerShell@2
         displayName: Stage nipkg directory for ${{ package.controlFileName }}
         inputs:


### PR DESCRIPTION
- [ ] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-custom-device-build-tools/blob/main/CONTRIBUTING.md).

TODO: Check the above box with an 'x' indicating you've read and followed [CONTRIBUTING.md](https://github.com/ni/niveristand-custom-device-build-tools/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Adds support for the optional exclusions field on entries in the packages parameter, so a package can be skipped for specific LabVIEW versions during the packaging stage.

Previously exclusions was only honored for buildSteps. s a result, version-specific packages (e.g. a package whose payload is only built for 2026) were still emitted for 2024 and 2025 — producing empty/near-empty .nipkg files in those year folders.

### Why should this Pull Request be merged?

Makes package-level exclusions behave consistently with build-step exclusions, which consumers already expect to work.


