### PR TITLE
Updated NetCore repo conversion in build pipeline

### DIFF
--- a/azure-templates/stages.yml
+++ b/azure-templates/stages.yml
@@ -154,10 +154,16 @@ stages:
             - ${{ if and(ne(parameters.repoName, '') ,eq(item.version, '2026') ,eq(item.bitness, '64bit')) }}:
               - task: PowerShell@2
                 displayName: Prepare NetCore repository
-                condition: and(succeeded(), eq(variables['ConvertNetCore'], 'true'))
+                condition: and(succeeded(), eq(lower(variables['ConvertNetCore']), 'true'))
                 inputs:
                   targetType: inline
                   script: |
+                    if ("$(ConvertNetCore)".ToLower() -ne "true")
+                    {
+                        Write-Host "Skipping."
+                        exit 0
+                    }
+
                     Write-Host "Debug code - Branch name is: $(Build.SourceBranch)"
                     $netCoreDir = "C:\NetCore"
 


### PR DESCRIPTION
- [ ] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-custom-device-build-tools/blob/main/CONTRIBUTING.md).

TODO: Check the above box with an 'x' indicating you've read and followed [CONTRIBUTING.md](https://github.com/ni/niveristand-custom-device-build-tools/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Updates stages.yml to add support for optional stage dependencies, NetCore repository conversion

### Why should this Pull Request be merged?

updated NetCore repo conversion in build pipeline
### What testing has been done?

None
